### PR TITLE
Allow both marshmallow and schematics to co-exist

### DIFF
--- a/dynamorm/__init__.py
+++ b/dynamorm/__init__.py
@@ -5,4 +5,4 @@
     from dynamorm import DynaModel
 
 """
-from .model import DynaModel
+from .model import DynaModel  # noqa

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -9,11 +9,6 @@ schema that is used for validating and marshalling your data.
 import inspect
 import logging
 
-try:
-    import simplejson as json
-except ImportError:
-    import json
-
 import six
 
 from .table import DynamoTable3
@@ -260,7 +255,7 @@ class DynaModel(object):
 
         :param dict query_kwargs: Extra parameters that should be passed through to the Table query function
         :param \*\*kwargs: The key(s) and value(s) to query based on
-        """
+        """  # noqa
         resp = cls.Table.query(query_kwargs=query_kwargs, **kwargs)
         return [
             cls.new_from_raw(raw)
@@ -290,7 +285,7 @@ class DynaModel(object):
 
         :param dict scan_kwargs: Extra parameters that should be passed through to the Table scan function
         :param \*\*kwargs: The key(s) and value(s) to filter based on
-        """
+        """  # noqa
         resp = cls.Table.scan(scan_kwargs=scan_kwargs, **kwargs)
         return [
             cls.new_from_raw(raw)

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -101,7 +101,11 @@ class DynamoTable3(object):
     @property
     def key_schema(self):
         """Return an appropriate KeySchema, based on our key attributes and the schema object"""
-        as_schema = lambda name, key_type: {'AttributeName': name, 'KeyType': key_type}
+        def as_schema(name, key_type):
+            return {
+                'AttributeName': name,
+                'KeyType': key_type
+            }
         schema = [as_schema(self.hash_key, 'HASH')]
         if self.range_key:
             schema.append(as_schema(self.range_key, 'RANGE'))
@@ -110,7 +114,11 @@ class DynamoTable3(object):
     @property
     def attribute_definitions(self):
         """Return an appropriate AttributeDefinitions, based on our key attributes and the schema object"""
-        as_def = lambda name, field: {'AttributeName': name, 'AttributeType': self.schema.field_to_dynamo_type(field)}
+        def as_def(name, field):
+            return {
+                'AttributeName': name,
+                'AttributeType': self.schema.field_to_dynamo_type(field)
+            }
         defs = [as_def(self.hash_key, self.schema.dynamorm_fields()[self.hash_key])]
         if self.range_key:
             defs.append(as_def(self.range_key, self.schema.dynamorm_fields()[self.range_key]))
@@ -164,7 +172,7 @@ class DynamoTable3(object):
         :param \*\*kwargs: All other keyword arguments are passed through to the `DynamoDB Table put_item`_ function.
 
         .. _DynamoDB Table put_item: http://boto3.readthedocs.io/en/latest/reference/services/dynamodb.html#DynamoDB.Table.put_item
-        """
+        """  # noqa
         return self.table.put_item(Item=item, **kwargs)
 
     def put_unique(self, item, **kwargs):

--- a/dynamorm/types/__init__.py
+++ b/dynamorm/types/__init__.py
@@ -1,8 +1,0 @@
-from .base import BaseModel
-try:
-    from ._schematics import Model
-except ImportError:
-    try:
-        from ._marshmallow import Model
-    except ImportError:
-        raise ImportError('One of marshmallow or schematics is required to use this library.')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.0.4',
+    version='0.0.5',
     description='DynamORM is a Python object relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,6 @@
 import logging
 import os
 
-try:
-    from urllib import urlretrieve
-except ImportError:
-    from urllib.request import urlretrieve
-
 import pytest
 
 from dynamorm import DynaModel  # , LocalIndex, GlobalIndex
@@ -79,6 +74,7 @@ def TestModel():
                 )
 
     return TestModel
+
 
 @pytest.fixture(scope='function')
 def TestModel_table(request, TestModel, dynamo_local):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -20,6 +20,7 @@ def test_put_get(TestModel, TestModel_table, dynamo_local):
     assert isinstance(first_one, TestModel)
     assert first_one.baz == 'lol' and first_one.count == 123
 
+
 def test_schema_change(TestModel, TestModel_table, dynamo_local):
     """Simulate a schema change and make sure we get the record correctly"""
     data = {'foo': '1', 'bar': '2', 'bad_key': 10}
@@ -69,6 +70,7 @@ def test_put_unique(TestModel, TestModel_table, dynamo_local):
 
     with pytest.raises(HashKeyExists):
         TestModel.put_unique({"foo": "third", "bar": "three", "baz": "waa", "count": 9})
+
 
 def test_get_invalid_field(TestModel):
     """Calling .get on an invalid field should result in an exception"""


### PR DESCRIPTION
I ran into a situation where I wanted to use Marshmallow for my Schema definition but I also had Schematics installed in my virtualenv, and since we tried the Schematics import first I ended up with a weird error about a missing key even though it was properly defined since the Schematics model clearly didn't know how to do anything with the Marshmallow fields I defined.

> `InvalidSchemaField: The hash key 'application' does not exist in the schema`

This allows both libraries to co-exist by peeking into the defined fields/types and then lazily importing the `Model` class when the metaclass is created.

CC @akshaynanavati -- mostly as an FYI.