### PR TITLE
Add scan generator for automatic results paging handling

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,7 @@ Example
     from marshmallow import fields
 
     # Our objects are defined as DynaModel classes
-    class Book(DyanModel):
+    class Book(DynaModel):
         # Define our DynamoDB properties
         class Table:
             name = 'prod-books'
@@ -100,7 +100,7 @@ Contents
 
 Indices and tables
 ------------------
- 
+
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -294,15 +294,8 @@ class DynaModel(object):
         :param dict dynamo_kwargs: Extra parameters that should be passed through from query_kwargs or scan_kwargs
         :param \*\*kwargs: The key(s) and value(s) to filter based on
         """
-        if method_name == 'scan':
-            method = cls.Table.scan
-            dynamo_kwargs_key = 'scan_kwargs'
-        elif method_name == 'query':
-            method = cls.Table.query
-            dynamo_kwargs_key = 'query_kwargs'
-        else:
-            raise ValueError('Method should be one of: scan,query')
-
+        method = getattr(cls.Table, method_name)
+        dynamo_kwargs_key  = '_'.join([method_name, 'kwargs'])
         all_kwargs = {dynamo_kwargs_key: dynamo_kwargs or {}}
         all_kwargs.update(kwargs)
 
@@ -323,7 +316,7 @@ class DynaModel(object):
 
                 # Stop if we've reached the limit set by the caller
                 if all_kwargs[dynamo_kwargs_key]['Limit'] <= 0:
-                    return
+                    break
 
             # Update calling kwargs with offset key
             all_kwargs[dynamo_kwargs_key]['ExclusiveStartKey'] = resp['LastEvaluatedKey']

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -283,25 +283,8 @@ class DynaModel(object):
             Thing.scan(address__state="CA")
             Thing.scan(address__state__begins_with="C")
 
-        :param dict scan_kwargs: Extra parameters that should be passed through to the Table scan function
-        :param \*\*kwargs: The key(s) and value(s) to filter based on
-        """  # noqa
-        resp = cls.Table.scan(scan_kwargs=scan_kwargs, **kwargs)
-        return [
-            cls.new_from_raw(raw)
-            for raw in resp['Items']
-            if raw is not None
-        ]
-
-    @classmethod
-    def gen_scan(cls, scan_kwargs=None, **kwargs):
-        """Execute a scan on our table, yielding items and abstracting away pagination
-
-        Identical to the scan method, but will produce an item generator instead of a list, and will continue to
-        generate until all items are produced instead of just returning the first page. Note that this will generate
-        individual scan results instead of the full page as a list, as is done in the scan method.
-
-        More information on scan pagination: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.Pagination
+        This returns a generator, which will continue to yield items until all matching the scan are produced,
+        abstracting away pagination. More information on scan pagination: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.Pagination
 
         :param dict scan_kwargs: Extra parameters that should be passed through to the Table scan function
         :param \*\*kwargs: The key(s) and value(s) to filter based on

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -256,12 +256,7 @@ class DynaModel(object):
         :param dict query_kwargs: Extra parameters that should be passed through to the Table query function
         :param \*\*kwargs: The key(s) and value(s) to query based on
         """  # noqa
-        resp = cls.Table.query(query_kwargs=query_kwargs, **kwargs)
-        return [
-            cls.new_from_raw(raw)
-            for raw in resp['Items']
-            if raw is not None
-        ]
+        return cls._yield_items('query', dynamo_kwargs=query_kwargs, **kwargs)
 
     @classmethod
     def scan(cls, scan_kwargs=None, **kwargs):
@@ -289,18 +284,50 @@ class DynaModel(object):
         :param dict scan_kwargs: Extra parameters that should be passed through to the Table scan function
         :param \*\*kwargs: The key(s) and value(s) to filter based on
         """  # noqa
-        resp = cls.Table.scan(scan_kwargs=scan_kwargs, **kwargs)
-        for raw in resp['Items']:
-            if raw is not None:
-                yield cls.new_from_raw(raw)
+        return cls._yield_items('scan', dynamo_kwargs=scan_kwargs, **kwargs)
 
-        while 'LastEvaluatedKey' in resp:
-            scan_kwargs = scan_kwargs or {}
-            scan_kwargs['ExclusiveStartKey'] = resp['LastEvaluatedKey']
-            resp = cls.Table.scan(scan_kwargs=scan_kwargs, **kwargs)
+    @classmethod
+    def _yield_items(cls, method_name, dynamo_kwargs=None, **kwargs):
+        """Private helper method to yield items from a scan or query response
+
+        :param method_name: The cls.Table.<method_name> that should be called (one of: 'scan','query'))
+        :param dict dynamo_kwargs: Extra parameters that should be passed through from query_kwargs or scan_kwargs
+        :param \*\*kwargs: The key(s) and value(s) to filter based on
+        """
+        if method_name == 'scan':
+            method = cls.Table.scan
+            dynamo_kwargs_key = 'scan_kwargs'
+        elif method_name == 'query':
+            method = cls.Table.query
+            dynamo_kwargs_key = 'query_kwargs'
+        else:
+            raise ValueError('Method should be one of: scan,query')
+
+        all_kwargs = {dynamo_kwargs_key: dynamo_kwargs or {}}
+        all_kwargs.update(kwargs)
+
+        while True:
+            # Fetch and yield values
+            resp = method(**all_kwargs)
             for raw in resp['Items']:
                 if raw is not None:
                     yield cls.new_from_raw(raw)
+
+            # Stop if no further pages
+            if 'LastEvaluatedKey' not in resp:
+                break
+
+            if 'Limit' in all_kwargs[dynamo_kwargs_key]:
+                # Reduce limit by amount scanned for subsequent calls
+                all_kwargs[dynamo_kwargs_key]['Limit'] -= resp['ScannedCount']
+
+                # Stop if we've reached the limit set by the caller
+                if all_kwargs[dynamo_kwargs_key]['Limit'] <= 0:
+                    return
+
+            # Update calling kwargs with offset key
+            all_kwargs[dynamo_kwargs_key]['ExclusiveStartKey'] = resp['LastEvaluatedKey']
+
 
     def to_dict(self):
         obj = {}

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -255,12 +255,13 @@ class DynamoTable3(object):
             assert len(parts) == 0, "Left over parts after parsing query attr"
 
             op = getattr(attr, op)
+            op_fn = op(value) if value is not None else op()
 
             if 'FilterExpression' in scan_kwargs:
                 # XXX TODO: support | (or) and ~ (not)
-                scan_kwargs['FilterExpression'] = scan_kwargs['FilterExpression'] & op(value)
+                scan_kwargs['FilterExpression'] = scan_kwargs['FilterExpression'] & op_fn
             else:
-                scan_kwargs['FilterExpression'] = op(value)
+                scan_kwargs['FilterExpression'] = op_fn
 
         return self.table.scan(**scan_kwargs)
 

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -259,7 +259,7 @@ class DynamoTable3(object):
                 filter_expression = op(value)
             except TypeError:
                 # A TypeError calling our attr op likely means we're invoking exists, not_exists or another op that
-                # doesn't take an arg if our value is True then we try to re-call the op function without any
+                # doesn't take an arg. If our value is True then we try to re-call the op function without any
                 # arguments, otherwise we bubble it up.
                 if value is True:
                     filter_expression = op()

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -255,13 +255,22 @@ class DynamoTable3(object):
             assert len(parts) == 0, "Left over parts after parsing query attr"
 
             op = getattr(attr, op)
-            op_fn = op(value) if value is not None else op()
+            try:
+                filter_expression = op(value)
+            except TypeError:
+                # A TypeError calling our attr op likely means we're invoking exists, not_exists or another op that
+                # doesn't take an arg if our value is True then we try to re-call the op function without any
+                # arguments, otherwise we bubble it up.
+                if value is True:
+                    filter_expression = op()
+                else:
+                    raise
 
             if 'FilterExpression' in scan_kwargs:
                 # XXX TODO: support | (or) and ~ (not)
-                scan_kwargs['FilterExpression'] = scan_kwargs['FilterExpression'] & op_fn
+                scan_kwargs['FilterExpression'] = scan_kwargs['FilterExpression'] & filter_expression
             else:
-                scan_kwargs['FilterExpression'] = op_fn
+                scan_kwargs['FilterExpression'] = filter_expression
 
         return self.table.scan(**scan_kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.0.11',
+    version='0.1.1',
     description='DynamORM is a Python object relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,6 +93,15 @@ def TestModel_entries(TestModel, TestModel_table):
     )
 
 
+@pytest.fixture(scope='function')
+def TestModel_entries_xlarge(TestModel, TestModel_table):
+    """Used with TestModel, creates and deletes the table and populates multiple pages of entries"""
+    TestModel.put_batch(*[
+        {"foo": str(i), "bar": "baz", "baz": "bat" * 100}
+        for i in range(4000)  # 1mb page is roughly 3300 items, so 4000 will be two pages.
+    ])
+
+
 @pytest.fixture(scope='session')
 def dynamo_local(request, TestModel):
     """Connect to a local dynamo instance"""

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -91,3 +91,16 @@ def test_number_hash_key():
 
     model = Model(foo=1, baz='foo')
     assert model.Table.attribute_definitions == [{'AttributeName': 'foo', 'AttributeType': 'N'}]
+
+
+def test_scan_gen(TestModel, TestModel_entries, dynamo_local):
+    """Test the scan generator to ensure paging works"""
+
+    # Apply artificial limit to force scan to page results
+    results = list(TestModel.gen_scan(scan_kwargs={'Limit': 2}, count__gt=0))
+    assert len(results) == 3
+
+    # our table has a hash and range key, so our results are ordered based on the range key
+    assert results[0].count == 111
+    assert results[1].count == 333
+    assert results[2].count == 222

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -91,16 +91,3 @@ def test_number_hash_key():
 
     model = Model(foo=1, baz='foo')
     assert model.Table.attribute_definitions == [{'AttributeName': 'foo', 'AttributeType': 'N'}]
-
-
-def test_scan_gen(TestModel, TestModel_entries, dynamo_local):
-    """Test the scan generator to ensure paging works"""
-
-    # Apply artificial limit to force scan to page results
-    results = list(TestModel.gen_scan(scan_kwargs={'Limit': 2}, count__gt=0))
-    assert len(results) == 3
-
-    # our table has a hash and range key, so our results are ordered based on the range key
-    assert results[0].count == 111
-    assert results[1].count == 333
-    assert results[2].count == 222

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -189,8 +189,13 @@ def test_yield_items(TestModel, mocker):
     assert results[0].count == 111
     assert results[1].count == 222
 
-    with pytest.raises(ValueError):
-        list(TestModel._yield_items('foo'))
+
+def test_yield_items_xlarge(TestModel, TestModel_entries_xlarge, dynamo_local, mocker):
+    mocker.spy(TestModel.Table.__class__, 'scan')
+    results = list(TestModel._yield_items('scan'))
+
+    assert TestModel.Table.scan.call_count == 2
+    assert len(results) == 4000
 
 
 def test_overwrite(TestModel, TestModel_entries, dynamo_local):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -189,6 +189,9 @@ def test_yield_items(TestModel, mocker):
     assert results[0].count == 111
     assert results[1].count == 222
 
+    with pytest.raises(ValueError):
+        list(TestModel._yield_items('foo'))
+
 
 def test_overwrite(TestModel, TestModel_entries, dynamo_local):
     """Putting an existing hash+range should replace the old entry"""

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -173,7 +173,7 @@ def test_yield_items(TestModel, mocker):
         'Items': [{'bar': 'two', 'baz': 'bbq', 'child': {'sub': 'one'}, 'count': Decimal('222'), 'foo': 'second'}],
         'ScannedCount': 1
     }]
-    mocker.patch.object(TestModel.Table.__class__, 'scan', side_effect=side_effects)
+    mocker.patch.object(TestModel.Table, 'scan', side_effect=side_effects)
     results = list(TestModel._yield_items('scan', dynamo_kwargs={"Limit": 2}))
 
     assert TestModel.Table.scan.call_count == 2
@@ -181,7 +181,7 @@ def test_yield_items(TestModel, mocker):
     assert results[0].count == 111
     assert results[1].count == 222
 
-    mocker.patch.object(TestModel.Table.__class__, 'query', side_effect=side_effects)
+    mocker.patch.object(TestModel.Table, 'query', side_effect=side_effects)
     results = list(TestModel._yield_items('query', dynamo_kwargs={"Limit": 2}))
 
     assert TestModel.Table.query.call_count == 2
@@ -191,7 +191,7 @@ def test_yield_items(TestModel, mocker):
 
 
 def test_yield_items_xlarge(TestModel, TestModel_entries_xlarge, dynamo_local, mocker):
-    mocker.spy(TestModel.Table.__class__, 'scan')
+    mocker.spy(TestModel.Table, 'scan')
     results = list(TestModel._yield_items('scan'))
 
     assert TestModel.Table.scan.call_count == 2

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -142,6 +142,12 @@ def test_scan(TestModel, TestModel_entries, dynamo_local):
     assert results[0].count == 333
     assert results[1].count == 222
 
+    # Test no arg operator
+    TestModel.put({"foo": "no_baz", "bar": "omg"})
+    results = TestModel.scan(baz__not_exists=None)
+    assert len(results) == 1
+    assert results[0].foo == "no_baz"
+
 
 def test_overwrite(TestModel, TestModel_entries, dynamo_local):
     """Putting an existing hash+range should replace the old entry"""


### PR DESCRIPTION
- Add scan generator to help page through scan results until all items are returned
  - Made as a second method rather than built-in to `scan` to preserve backwards compatibility
- Add support for scan conditionals with no args
  - Passing None as the value in kwargs will allow conditionals with no
args, such as `not_exists`