### PR TITLE
Support subclassed DynaModels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.1.1',
+    version='0.1.2',
     description='DynamORM is a Python object relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -34,6 +34,22 @@ def test_missing_inner_table_class():
                 pass
 
 
+def test_parent_inner_classes():
+    class Parent(DynaModel):
+        class Table:
+            name = 'table'
+            hash_key = 'foo'
+            read = 1
+            write = 1
+
+        class Schema:
+            foo = String(required=True)
+
+    class Child(Parent):
+        pass
+
+    assert Child.Table is Parent.Table
+
 def test_table_validation():
     """Defining a model with missing table attributes should raise exceptions"""
     with pytest.raises(MissingTableAttribute):


### PR DESCRIPTION
If you try to use subclasses of a DynaModel you end up with an error from the metaclass:

```
DynaModelException: You must define an inner 'Table' class on your 'AWSTarget' class
```

This changes the `__new__` logic so that we also check our parent classes when processing a classes schema & table.