### PR TITLE
Add update functionality to tables and models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ python:
   - pypy
 
 env:
-  - SERIALIZATION_PKG="marshmallow==2.7.0"
-  - SERIALIZATION_PKG="schematics==1.0.4"
+  - SERIALIZATION_PKG="marshmallow==2.13.5"
+  - SERIALIZATION_PKG="schematics==2.0.1"
 
 install: false
 script: ./build.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ indy {
     type = 'app-2017-05-23'
     debug = true
 
-    setupExtra = [
+    extraSetup = [
       'pip install schematics==2.0.1 marshmallow==2.13.5'
     ]
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,10 @@
 #!groovy
 
 indy {
-    type = 'python'
+    type = 'app-2017-05-23'
+    debug = true
+
+    setupExtra = [
+      'pip install schematics==2.0.1 marshmallow==2.13.5'
+    ]
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,9 +2,4 @@
 
 indy {
     type = 'app-2017-05-23'
-    debug = true
-
-    extraSetup = [
-      'pip install schematics==2.0.1 marshmallow==2.13.5'
-    ]
 }

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,12 @@ The project has two goals:
 .. _Schematics: https://schematics.readthedocs.io/en/latest/
 
 
+Supported Versions
+------------------
+
+* Schematics >= 2.0
+* Marshmallow >= 2.0
+
 Example
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -113,10 +113,13 @@ TODO
 
 These are broken down by milestone release.
 
-0.1.0
+0.2.0
+-----
+* Partial updates on ``save()``
+
+0.3.0
 -----
 * Indexes -- Currently there is no support for indexes.
-* Partial updates on ``save()``
 
 1.0.0
 -----

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ pip install -e .
 pip install codecov pytest pytest-mock
 pip install ${SERIALIZATION_PKG}
 
-SERIALIZATION_PKG=${SERIALIZATION_PKG} coverage run --source=dynamorm py.test -v tests/
+SERIALIZATION_PKG=${SERIALIZATION_PKG} coverage run --source=dynamorm $(which py.test) -v tests/
 
 if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
     if [ -z "`git diff origin/master setup.py | grep '\+.*version='`" ]; then

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ pip install -e .
 pip install codecov pytest pytest-mock
 pip install ${SERIALIZATION_PKG}
 
-SERIALIZATION_PKG=${SERIALIZATION_PKG} coverage run --source=dynamorm setup.py test
+SERIALIZATION_PKG=${SERIALIZATION_PKG} coverage run --source=dynamorm py.test -v tests/
 
 if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
     if [ -z "`git diff origin/master setup.py | grep '\+.*version='`" ]; then

--- a/dynamorm/exceptions.py
+++ b/dynamorm/exceptions.py
@@ -48,3 +48,7 @@ class InvalidKey(DynamoTableException):
 
 class HashKeyExists(DynamoTableException):
     """A operating requesting a unique hash key failed"""
+
+
+class ConditionFailed(DynamoTableException):
+    """A condition check failed"""

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -6,7 +6,6 @@ schema that is used for validating and marshalling your data.
 
 """
 
-import inspect
 import logging
 
 import six
@@ -345,7 +344,6 @@ class DynaModel(object):
 
             # Update calling kwargs with offset key
             all_kwargs[dynamo_kwargs_key]['ExclusiveStartKey'] = resp['LastEvaluatedKey']
-
 
     def to_dict(self):
         obj = {}

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -229,6 +229,17 @@ class DynaModel(object):
         ], **batch_kwargs)
 
     @classmethod
+    def update(cls, conditions=None, update_item_kwargs=None, **kwargs):
+        """Update a item in the table
+
+        :params conditions: A dict of key/val pairs that should be applied as a condition to the update
+        :params update_item_kwargs: A dict of other kwargs that are passed through to update_item
+        :params \*\*kwargs: Includes your hash/range key/val to match on as well as any keys to update
+        """
+        cls.Schema.dynamorm_validate(kwargs, partial=True)
+        return cls.Table.update(conditions=conditions, update_item_kwargs=update_item_kwargs, **kwargs)
+
+    @classmethod
     def new_from_raw(cls, raw):
         """Return a new instance of this model from a raw (dict) of data that is loaded by our Schema
 

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -55,7 +55,7 @@ class DynaModelMeta(type):
         # to allow both schematics and marshmallow to be installed and select the correct model we peek inside of the
         # dict and see if the item comes from either of them and lazily import our local Model implementation
         if should_transform('Schema'):
-            for _, schema_item in six.iteritems(attrs['Schema'].__dict__):
+            for schema_item in six.itervalues(attrs['Schema'].__dict__):
                 try:
                     module_name = schema_item.__module__
                 except AttributeError:
@@ -309,7 +309,7 @@ class DynaModel(object):
         :param \*\*kwargs: The key(s) and value(s) to filter based on
         """
         method = getattr(cls.Table, method_name)
-        dynamo_kwargs_key  = '_'.join([method_name, 'kwargs'])
+        dynamo_kwargs_key = '_'.join([method_name, 'kwargs'])
         all_kwargs = {dynamo_kwargs_key: dynamo_kwargs or {}}
         all_kwargs.update(kwargs)
 

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -228,7 +228,7 @@ class DynaModel(object):
         ], **batch_kwargs)
 
     @classmethod
-    def update(cls, conditions=None, update_item_kwargs=None, **kwargs):
+    def update_item(cls, conditions=None, update_item_kwargs=None, **kwargs):
         """Update a item in the table
 
         :params conditions: A dict of key/val pairs that should be applied as a condition to the update
@@ -362,3 +362,13 @@ class DynaModel(object):
         # XXX TODO: do partial updates if we know the item already exists, right now we just blindly put the whole
         # XXX TODO: item on every save
         return self.put(self.to_dict(), **kwargs)
+
+    def update(self, conditions=None, update_item_kwargs=None, **kwargs):
+        """Update this instance in the table"""
+        kwargs[self.Table.hash_key] = getattr(self, self.Table.hash_key)
+        try:
+            kwargs[self.Table.range_key] = getattr(self, self.Table.range_key)
+        except (AttributeError, TypeError):
+            pass
+
+        return self.update_item(conditions=conditions, update_item_kwargs=update_item_kwargs, **kwargs)

--- a/dynamorm/types/_marshmallow.py
+++ b/dynamorm/types/_marshmallow.py
@@ -25,8 +25,8 @@ class Model(Schema, BaseModel):
         return cls._dynamorm_fields
 
     @classmethod
-    def dynamorm_validate(cls, obj):
-        data, errors = cls().load(obj)
+    def dynamorm_validate(cls, obj, partial=False):
+        data, errors = cls().load(obj, partial=partial)
         if errors:
             raise ValidationError(obj, cls.__name__, errors)
         return data

--- a/dynamorm/types/_schematics.py
+++ b/dynamorm/types/_schematics.py
@@ -21,8 +21,8 @@ class Model(SchematicsModel, BaseModel):
         return cls.fields
 
     @classmethod
-    def dynamorm_validate(cls, obj):
+    def dynamorm_validate(cls, obj, partial=False):
         try:
-            return cls(obj, strict=False).to_primitive()
+            return cls(obj, strict=False, partial=partial).to_primitive()
         except (SchematicsValidationError, ModelConversionError) as e:
             raise ValidationError(obj, cls.__name__, e.messages)

--- a/dynamorm/types/base.py
+++ b/dynamorm/types/base.py
@@ -18,7 +18,7 @@ class BaseModel(object):
         raise NotImplementedError('{0} class must implement dynamallow_fields'.format(cls.__name__))
 
     @classmethod
-    def dynamallow_validate(cls, obj):
+    def dynamallow_validate(cls, obj, partial=False):
         """
         Given a dictionary representing a blob from dynamo, this method will validate the blob
         given the desired validation library.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,7 @@ pytest==2.9.2
 python-dateutil==2.6.0    # via botocore
 s3transfer==0.1.10        # via boto3
 six==1.10.0
+
+# MANUALLY ADDED FOR TESTING
+schematics==2.0.1
+marshmallow==2.13.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+boto3==1.4.4
+botocore==1.5.19          # via boto3, s3transfer
+docutils==0.13.1          # via botocore
+futures==3.0.5            # via s3transfer
+jmespath==0.9.1           # via boto3, botocore
+py==1.4.31                # via pytest
+pytest==2.9.2
+python-dateutil==2.6.0    # via botocore
+s3transfer==0.1.10        # via boto3
+six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.1.2',
+    version='0.1.3',
     description='DynamORM is a Python object relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,6 @@ setup(
         'boto3>=1.3,<2.0',
         'six',
     ],
-    tests_requires=[
-        'pytest>=2.9,<3.0',
-        'pytest-runner',
-    ],
     packages=find_packages('.', exclude=['tests', 'docs']),
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -13,13 +13,13 @@ setup(
     url='https://github.com/NerdWalletOSS/DynamORM',
     license='Apache License Version 2.0',
 
-    setup_requires=[
-        'pytest-runner',
-    ],
     install_requires=[
         'boto3>=1.3,<2.0',
-        'pytest>=2.9,<3.0',
         'six',
+    ],
+    tests_requires=[
+        'pytest>=2.9,<3.0',
+        'pytest-runner',
     ],
     packages=find_packages('.', exclude=['tests', 'docs']),
     classifiers=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def TestModel():
             class Schema:
                 foo = fields.String(required=True)
                 bar = fields.String(required=True)
-                baz = fields.String()
+                baz = fields.String(required=True)
                 count = fields.Integer()
                 child = fields.Dict()
 
@@ -63,7 +63,7 @@ def TestModel():
             class Schema:
                 foo = types.StringType(required=True)
                 bar = types.StringType(required=True)
-                baz = types.StringType()
+                baz = types.StringType(required=True)
                 count = types.IntType()
                 child = compound.DictType(types.StringType)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,49 @@ def TestModel_entries_xlarge(TestModel, TestModel_table):
 
 
 @pytest.fixture(scope='session')
+def TestModelTwo():
+    """Provides a test model without a range key"""
+
+    if 'marshmallow' in (os.getenv('SERIALIZATION_PKG') or ''):
+        from marshmallow import fields
+
+        class TestModelTwo(DynaModel):
+            class Table:
+                name = 'peanut-butter'
+                hash_key = 'foo'
+                read = 5
+                write = 5
+
+            class Schema:
+                foo = fields.String(required=True)
+                bar = fields.String()
+                baz = fields.String()
+    else:
+        from schematics import types
+
+        class TestModelTwo(DynaModel):
+            class Table:
+                name = 'peanut-butter'
+                hash_key = 'foo'
+                read = 5
+                write = 5
+
+            class Schema:
+                foo = types.StringType(required=True)
+                bar = types.StringType()
+                baz = types.StringType()
+
+    return TestModelTwo
+
+
+@pytest.fixture(scope='function')
+def TestModelTwo_table(request, TestModelTwo, dynamo_local):
+    """Used with TestModel, creates and deletes the table around the test"""
+    TestModelTwo.Table.create()
+    request.addfinalizer(TestModelTwo.Table.delete)
+
+
+@pytest.fixture(scope='session')
 def dynamo_local(request, TestModel):
     """Connect to a local dynamo instance"""
     dynamo_local_dir = os.environ.get('DYNAMO_LOCAL', 'build/dynamo-local')

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -61,6 +61,44 @@ def test_table_validation():
                 foo = String(required=True)
 
 
+def test_table_create_validation():
+    """You cannot create a table that is missing read/write attrs"""
+    with pytest.raises(MissingTableAttribute):
+        class Model(DynaModel):
+            class Table:
+                name = 'table'
+                hash_key = 'foo'
+                read = 5
+
+            class Schema:
+                foo = String(required=True)
+
+        Model.Table.create()
+
+    with pytest.raises(MissingTableAttribute):
+        class Model(DynaModel):
+            class Table:
+                name = 'table'
+                hash_key = 'foo'
+                write = 5
+
+            class Schema:
+                foo = String(required=True)
+
+        Model.Table.create()
+
+    with pytest.raises(MissingTableAttribute):
+        class Model(DynaModel):
+            class Table:
+                name = 'table'
+                hash_key = 'foo'
+
+            class Schema:
+                foo = String(required=True)
+
+        Model.Table.create()
+
+
 def test_invalid_hash_key():
     """Defining a model where ``hash_key`` in Table points to an invalid field should raise InvalidSchemaField"""
     with pytest.raises(InvalidSchemaField):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -50,6 +50,7 @@ def test_parent_inner_classes():
 
     assert Child.Table is Parent.Table
 
+
 def test_table_validation():
     """Defining a model with missing table attributes should raise exceptions"""
     with pytest.raises(MissingTableAttribute):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -56,7 +56,6 @@ def test_table_validation():
         class Model(DynaModel):
             class Table:
                 name = 'table'
-                hash_key = 'foo'
 
             class Schema:
                 foo = String(required=True)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -208,6 +208,32 @@ def test_update_validation(TestModel, TestModel_entries, dynamo_local):
             baz=['not a list']
         )
 
+
+def test_update_invalid_fields(TestModel, TestModel_entries, dynamo_local):
+    with pytest.raises(InvalidSchemaField):
+        TestModel.update(
+            # our hash & range key -- matches current
+            foo='first',
+            bar='two',
+
+            # things to update
+            unknown_attr='foo'
+        )
+
+    with pytest.raises(InvalidSchemaField):
+        TestModel.update(
+            # our hash & range key -- matches current
+            foo='first',
+            bar='two',
+
+            # things to update
+            baz='foo',
+
+            conditions=dict(
+                unknown_attr='foo'
+            )
+        )
+
 def test_yield_items(TestModel, mocker):
     # Mock out Dynamo responses as each having only one item to test auto-paging
     side_effects = [{

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -234,6 +234,7 @@ def test_update_invalid_fields(TestModel, TestModel_entries, dynamo_local):
             )
         )
 
+
 def test_yield_items(TestModel, mocker):
     # Mock out Dynamo responses as each having only one item to test auto-paging
     side_effects = [{

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -167,22 +167,24 @@ def test_update(TestModel, TestModel_entries, dynamo_local):
     two = TestModel.get(foo="first", bar="two")
     assert two.baz == 'wtf'
 
-    TestModel.update(
-        # our hash & range key -- matches current
-        foo='first',
-        bar='two',
-
-        # things to update
-        baz='yay'
-    )
+    two.update(baz='yay')
 
     two = TestModel.get(foo="first", bar="two", consistent=True)
     assert two.baz == 'yay'
 
 
+def test_update_no_range(TestModelTwo, TestModelTwo_table, dynamo_local):
+    TestModelTwo.put({'foo': 'foo', 'bar': 'bar'})
+    thing = TestModelTwo.get(foo='foo')
+    thing.update(baz='illion')
+
+    new = TestModelTwo.get(foo='foo', consistent=True)
+    assert new.baz == 'illion'
+
+
 def test_update_conditions(TestModel, TestModel_entries, dynamo_local):
     with pytest.raises(ConditionFailed):
-        TestModel.update(
+        TestModel.update_item(
             # our hash & range key -- matches current
             foo='first',
             bar='two',
@@ -199,7 +201,7 @@ def test_update_conditions(TestModel, TestModel_entries, dynamo_local):
 
 def test_update_validation(TestModel, TestModel_entries, dynamo_local):
     with pytest.raises(ValidationError):
-        TestModel.update(
+        TestModel.update_item(
             # our hash & range key -- matches current
             foo='first',
             bar='two',
@@ -211,7 +213,7 @@ def test_update_validation(TestModel, TestModel_entries, dynamo_local):
 
 def test_update_invalid_fields(TestModel, TestModel_entries, dynamo_local):
     with pytest.raises(InvalidSchemaField):
-        TestModel.update(
+        TestModel.update_item(
             # our hash & range key -- matches current
             foo='first',
             bar='two',
@@ -221,7 +223,7 @@ def test_update_invalid_fields(TestModel, TestModel_entries, dynamo_local):
         )
 
     with pytest.raises(InvalidSchemaField):
-        TestModel.update(
+        TestModel.update_item(
             # our hash & range key -- matches current
             foo='first',
             bar='two',

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -2,7 +2,7 @@
 from decimal import Decimal
 import pytest
 
-from dynamorm.exceptions import HashKeyExists, InvalidSchemaField, ValidationError
+from dynamorm.exceptions import HashKeyExists, InvalidSchemaField, ValidationError, ConditionFailed
 
 
 def test_table_creation_deletion(TestModel, dynamo_local):
@@ -26,16 +26,16 @@ def test_put_remove_nones(TestModel, TestModel_table, dynamo_local, mocker):
     # mock out the underlying table resource, we have to reach deep in to find it...
     mocker.patch.object(TestModel.Table.__class__, '_table')
 
-    TestModel.put({'foo': 'first', 'bar': 'one'})
+    TestModel.put({'foo': 'first', 'bar': 'one', 'baz': 'baz'})
 
     TestModel.Table.__class__._table.put_item.assert_called_with(
-        Item={'foo': 'first', 'bar': 'one'}
+        Item={'foo': 'first', 'bar': 'one', 'baz': 'baz'}
     )
 
 
 def test_schema_change(TestModel, TestModel_table, dynamo_local):
     """Simulate a schema change and make sure we get the record correctly"""
-    data = {'foo': '1', 'bar': '2', 'bad_key': 10}
+    data = {'foo': '1', 'bar': '2', 'bad_key': 10, 'baz': 'baz'}
     TestModel.Table.put(data)
     item = TestModel.get(foo='1', bar='2')
     assert item._raw == data
@@ -153,15 +153,60 @@ def test_scan(TestModel, TestModel_entries, dynamo_local):
     assert results[0].count == 111
     assert results[1].count == 333
 
-    TestModel.put({"foo": "no_baz", "bar": "omg"})
-    results = list(TestModel.scan(baz__not_exists=True))
+    TestModel.put({"foo": "no_child", "bar": "omg", "baz": "baz"})
+    results = list(TestModel.scan(child__not_exists=True))
     assert len(results) == 1
-    assert results[0].foo == "no_baz"
+    assert results[0].foo == "no_child"
 
     with pytest.raises(TypeError):
         # Make sure we reject if the value isn't True
         list(TestModel.scan(baz__not_exists=False))
 
+
+def test_update(TestModel, TestModel_entries, dynamo_local):
+    two = TestModel.get(foo="first", bar="two")
+    assert two.baz == 'wtf'
+
+    TestModel.update(
+        # our hash & range key -- matches current
+        foo='first',
+        bar='two',
+
+        # things to update
+        baz='yay'
+    )
+
+    two = TestModel.get(foo="first", bar="two", consistent=True)
+    assert two.baz == 'yay'
+
+
+def test_update_conditions(TestModel, TestModel_entries, dynamo_local):
+    with pytest.raises(ConditionFailed):
+        TestModel.update(
+            # our hash & range key -- matches current
+            foo='first',
+            bar='two',
+
+            # things to update
+            baz='yay',
+
+            # things to check
+            conditions=dict(
+                baz='nope',
+            )
+        )
+
+
+def test_update_validation(TestModel, TestModel_entries, dynamo_local):
+    with pytest.raises(ValidationError):
+        TestModel.update(
+            # our hash & range key -- matches current
+            foo='first',
+            bar='two',
+
+            # things to update
+            baz=['not a list']
+        )
 
 def test_yield_items(TestModel, mocker):
     # Mock out Dynamo responses as each having only one item to test auto-paging
@@ -216,7 +261,7 @@ def test_overwrite(TestModel, TestModel_entries, dynamo_local):
 
 
 def test_save(TestModel, TestModel_table, dynamo_local):
-    test_model = TestModel(foo='a', bar='b', count=100)
+    test_model = TestModel(foo='a', bar='b', baz='c', count=100)
     test_model.save()
     result = TestModel.get(foo='a', bar='b')
     assert result.foo == 'a'
@@ -244,13 +289,13 @@ def test_save_update(TestModel, TestModel_entries, dynamo_local):
 
 
 def test_consistent_read(TestModel, TestModel_entries, dynamo_local):
-    test_model = TestModel(foo='a', bar='b', count=100)
+    test_model = TestModel(foo='a', bar='b', baz='c', count=100)
     test_model.save()
 
     test_model = TestModel.get(foo='a', bar='b')
     assert test_model.count == 100
 
-    TestModel(foo='a', bar='b', count=200).save()
+    TestModel(foo='a', bar='b', baz='c', count=200).save()
 
     test_model = TestModel.get(foo='a', bar='b', consistent=True)
     assert test_model.count == 200


### PR DESCRIPTION
This PR adds update methods to both models and tables.

There are two model methods, one that operates at the class level (`.update_item`) where you supply the hash/range keys along with your conditions and args, and one that operates at the instance level (`.update`) where the hash/range keys are provided for you.

If you pass fields in the `conditions` kwarg then those become conditions that must pass for the update to succeed.  If they don't then the new `ConditionFailed` exception is raised.

This is the foundation for a more object based approach to partial updates where we can track changes to attrs between the time the object is loaded and the time that `.save(partial=True)` is called and then only update what has changed.

----

Other notable changes:

* **We now require schematics >= 2.0**, which was just released recently (less than 2 weeks ago).  Prior to 2.0 partial validation wasn't working correctly.  While I built this PR I did so in a new virtualenv where I manually installed schematics and just so happened to get 2.0.1, but once it landed in Travis it failed because we pinned an older version of schematics.

* `dynamorm_validate` now takes a `partial` argument that defaults to `False`.  This was required to get the validation of updated params working correctly.

* `read` & `write` table attrs are no longer required since having the ability to create the table isn't actually required.

----

fyi / happy to take feedback @ahollenbach (pre or post merge)