### PR TITLE
Add batch get for Models / Tables

### DIFF
--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -263,14 +263,14 @@ class DynaModel(object):
         return cls.new_from_raw(item)
 
     @classmethod
-    def get_batch(cls, *keys, consistent=False, attrs=None):
+    def get_batch(cls, keys, consistent=False, attrs=None):
         """Generator to get more than one item from the table.
 
-        :param \*keys: One or more dicts containing the hash key, and range key if used
+        :param keys: One or more dicts containing the hash key, and range key if used
         :param bool consistent: If set to True then get_batch will be a consistent read
         :param str attrs: The projection expression of which attrs to fetch, if None all attrs will be fetched
         """
-        items = cls.Table.get_batch(*keys, consistent=consistent, attrs=attrs)
+        items = cls.Table.get_batch(keys, consistent=consistent, attrs=attrs)
         for item in items:
             yield cls.new_from_raw(item, partial=attrs is not None)
 

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -246,7 +246,7 @@ class DynaModel(object):
         """
         if raw is None:
             return None
-        return cls(**raw, partial=partial)
+        return cls(partial=partial, **raw)
 
     @classmethod
     def get(cls, consistent=False, **kwargs):

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -177,14 +177,14 @@ class DynaModel(object):
                 ))
     """
 
-    def __init__(self, **raw):
+    def __init__(self, partial=False, **raw):
         """Create a new instance of a DynaModel
 
         :param \*\*raw: The raw data as pulled out of dynamo. This will be validated and the sanitized
         input will be put onto ``self`` as attributes.
         """
         self._raw = raw
-        data = self.Schema.dynamorm_validate(raw)
+        data = self.Schema.dynamorm_validate(raw, partial=partial)
         for k, v in six.iteritems(data):
             setattr(self, k, v)
 
@@ -239,14 +239,14 @@ class DynaModel(object):
         return cls.Table.update(conditions=conditions, update_item_kwargs=update_item_kwargs, **kwargs)
 
     @classmethod
-    def new_from_raw(cls, raw):
+    def new_from_raw(cls, raw, partial=False):
         """Return a new instance of this model from a raw (dict) of data that is loaded by our Schema
 
         :param dict raw: The attributes to use when creating the instance
         """
         if raw is None:
             return None
-        return cls(**raw)
+        return cls(**raw, partial=partial)
 
     @classmethod
     def get(cls, consistent=False, **kwargs):
@@ -257,10 +257,22 @@ class DynaModel(object):
             Thing.get(hash_key="three")
 
         :param bool consistent: If set to True the get will be a consistent read
-        :param \*\*kwargs: You must supply your hash key, and range key if used, with the values to get
+        :param \*\*kwargs: You must supply your hash key, and range key if used
         """
         item = cls.Table.get(consistent=consistent, **kwargs)
         return cls.new_from_raw(item)
+
+    @classmethod
+    def get_batch(cls, *keys, consistent=False, attrs=None):
+        """Generator to get more than one item from the table.
+
+        :param \*keys: One or more dicts containing the hash key, and range key if used
+        :param bool consistent: If set to True then get_batch will be a consistent read
+        :param str attrs: The projection expression of which attrs to fetch, if None all attrs will be fetched
+        """
+        items = cls.Table.get_batch(*keys, consistent=consistent, attrs=attrs)
+        for item in items:
+            yield cls.new_from_raw(item, partial=attrs is not None)
 
     @classmethod
     def query(cls, query_kwargs=None, **kwargs):

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -234,6 +234,37 @@ class DynamoTable3(object):
                 raise ConditionFailed(exc)
             raise
 
+    def get_batch(self, *keys, consistent=False, attrs=None, batch_get_kwargs=None):
+        batch_get_kwargs = batch_get_kwargs or {}
+
+        batch_get_kwargs['Keys'] = []
+        for kwargs in keys:
+            for k, v in six.iteritems(kwargs):
+                if k not in self.schema.dynamorm_fields():
+                    raise InvalidSchemaField("{0} does not exist in the schema fields".format(k))
+
+            batch_get_kwargs['Keys'].append(kwargs)
+
+        if consistent:
+            batch_get_kwargs['ConsistentRead'] = True
+
+        if attrs:
+            batch_get_kwargs['ProjectionExpression'] = attrs
+
+        while True:
+            response = self.resource.batch_get_item(RequestItems={
+                self.name: batch_get_kwargs
+            })
+
+            for item in response['Responses'][self.name]:
+                yield item
+
+            try:
+                batch_get_kwargs = response['UnprocessedKeys'][self.name]
+            except KeyError:
+                # once our table is no longer listed in UnprocessedKeys we're done our while True loop
+                break
+
     def get(self, consistent=False, get_item_kwargs=None, **kwargs):
         get_item_kwargs = get_item_kwargs or {}
 

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -234,7 +234,7 @@ class DynamoTable3(object):
                 raise ConditionFailed(exc)
             raise
 
-    def get_batch(self, *keys, consistent=False, attrs=None, batch_get_kwargs=None):
+    def get_batch(self, keys, consistent=False, attrs=None, batch_get_kwargs=None):
         batch_get_kwargs = batch_get_kwargs or {}
 
         batch_get_kwargs['Keys'] = []

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.1.4',
+    version='0.1.5',
     description='DynamORM is a Python object relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -76,6 +76,14 @@ def test_get_batch(TestModel, TestModel_entries, dynamo_local):
     assert 'three' in item_bars
 
 
+def test_get_batch_invalid_field(TestModel):
+    """Calling .get_batch on an invalid field should result in an exception"""
+    with pytest.raises(InvalidSchemaField):
+        list(TestModel.get_batch(keys=(
+            {'invalid': 'nope'},
+        )))
+
+
 def test_get_non_existant(TestModel, TestModel_table, dynamo_local):
     """Getting a non-existant item should return None"""
     assert TestModel.get(foo="fifth", bar="derp") is None

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -63,8 +63,10 @@ def test_put_batch(TestModel, TestModel_table, dynamo_local):
 
 def test_get_batch(TestModel, TestModel_entries, dynamo_local):
     items = TestModel.get_batch(
-        {'foo': 'first', 'bar': 'one'},
-        {'foo': 'first', 'bar': 'three'},
+        keys=(
+            {'foo': 'first', 'bar': 'one'},
+            {'foo': 'first', 'bar': 'three'},
+        ),
         attrs='bar'
     )
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -61,6 +61,19 @@ def test_put_batch(TestModel, TestModel_table, dynamo_local):
     assert second_one.baz == 'bbq' and second_one.count == 456
 
 
+def test_get_batch(TestModel, TestModel_entries, dynamo_local):
+    items = TestModel.get_batch(
+        {'foo': 'first', 'bar': 'one'},
+        {'foo': 'first', 'bar': 'three'},
+        attrs='bar'
+    )
+
+    item_bars = [item.bar for item in items]
+    assert 'one' in item_bars
+    assert 'two' not in item_bars
+    assert 'three' in item_bars
+
+
 def test_get_non_existant(TestModel, TestModel_table, dynamo_local):
     """Getting a non-existant item should return None"""
     assert TestModel.get(foo="fifth", bar="derp") is None


### PR DESCRIPTION
Fetching many models at the same time is expensive due to RTT on the calls to dynamo.

This PR adds `get_batch` methods to the Model & Table classes that allow you to fetch multiple items at the same time.