### PR TITLE
Ensure objects get native Python data types

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,13 +123,10 @@ TODO
 
 These are broken down by milestone release.
 
-0.2.0
------
-* Partial updates on ``save()``
-
 0.3.0
 -----
 * Indexes -- Currently there is no support for indexes.
+* Partial updates on ``save()``
 
 1.0.0
 -----

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -184,7 +184,7 @@ class DynaModel(object):
         input will be put onto ``self`` as attributes.
         """
         self._raw = raw
-        data = self.Schema.dynamorm_validate(raw, partial=partial)
+        data = self.Schema.dynamorm_validate(raw, partial=partial, native=True)
         for k, v in six.iteritems(data):
             setattr(self, k, v)
 

--- a/dynamorm/types/_marshmallow.py
+++ b/dynamorm/types/_marshmallow.py
@@ -25,8 +25,11 @@ class Model(Schema, BaseModel):
         return cls._dynamorm_fields
 
     @classmethod
-    def dynamorm_validate(cls, obj, partial=False):
-        data, errors = cls().load(obj, partial=partial)
+    def dynamorm_validate(cls, obj, partial=False, native=False):
+        if native:
+            data, errors = cls(partial=partial).dump(obj)
+        else:
+            data, errors = cls().load(obj, partial=partial)
         if errors:
             raise ValidationError(obj, cls.__name__, errors)
         return data

--- a/dynamorm/types/_schematics.py
+++ b/dynamorm/types/_schematics.py
@@ -21,8 +21,13 @@ class Model(SchematicsModel, BaseModel):
         return cls.fields
 
     @classmethod
-    def dynamorm_validate(cls, obj, partial=False):
+    def dynamorm_validate(cls, obj, partial=False, native=False):
         try:
-            return cls(obj, strict=False, partial=partial).to_primitive()
+            inst = cls(obj, strict=False, partial=partial)
         except (SchematicsValidationError, ModelConversionError) as e:
             raise ValidationError(obj, cls.__name__, e.messages)
+
+        if native:
+            return inst.to_native()
+        else:
+            return inst.to_primitive()

--- a/dynamorm/types/base.py
+++ b/dynamorm/types/base.py
@@ -2,7 +2,7 @@ class BaseModel(object):
     """``BaseModel`` is the base class for ``types.Model``. It must define ``dynamallow_validate`` which runs validation
     in your desired serialization library, ``dynamallow_fields`` which returns a dictionary of key value pairs
     where keys are attributes and values are the type of the attribute, and ``field_to_dynamo_type`` which returns
-    the dynamo type character for the input type (we implement schematics_ and marshmallow_).
+    the dynamo type character for the input type (we currently implement schematics_ and marshmallow_).
 
     .. _schematics: https://schematics.readthedocs.io/en/latest/
     .. _marshmallow: https://marshmallow.readthedocs.io/en/latest/
@@ -18,12 +18,17 @@ class BaseModel(object):
         raise NotImplementedError('{0} class must implement dynamallow_fields'.format(cls.__name__))
 
     @classmethod
-    def dynamallow_validate(cls, obj, partial=False):
+    def dynamallow_validate(cls, obj, partial=False, native=False):
         """
         Given a dictionary representing a blob from dynamo, this method will validate the blob
         given the desired validation library.
 
-        Returns a dictionary representing the sanitized input ``obj``. On validation failure,
-        this should raise ``dynamallow.exc.ValidationError``.
+        If partial is true then the underlying validation library should allow for partial objects.
+
+        If native is true then the underlying validation library should return a dictionary of native python values
+        (i.e. datetime.datetime), otherwise it should return a dictionary of primitive values (i.e. a string
+        representation of a date time value).
+
+        On validation failure, this should raise ``dynamallow.exc.ValidationError``.
         """
         raise NotImplementedError('{0} class must implement dynamallow_validate'.format(cls.__name__))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.1.7',
+    version='0.2.1',
     description='DynamORM is a Python object relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',


### PR DESCRIPTION
This PR adds a `native` option to the `dynamorm_validate` method on our type shims to the underlying validation libraries.

If native is truthy then the validation should return native Python objects (i.e. `datetime.datetime`), otherwise it should return primitive values suitable for JSON (i.e. a string representing the date & time).