### PR TITLE
More testing around native types

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
 
 indy {
-    type = 'ubuntu-2017.05.23'
+    base = 'ubuntu-2017.05.23'
 }

--- a/README.rst
+++ b/README.rst
@@ -113,9 +113,13 @@ Example
 Documentation
 =============
 
-Full documentation can be found online at:
+Full documentation is built from the sources each build and can be found online at:
 
 https://nerdwalletoss.github.io/dynamorm/
+
+
+The ``tests/`` also contain the most complete documentation on how to actually use the library, so you are encouraged to
+read through them to really familiarize yourself with some of the more advanced concepts and use cases.
 
 
 TODO

--- a/build.sh
+++ b/build.sh
@@ -24,5 +24,7 @@ if [ "${TRAVIS_PYTHON_VERSION}" = "2.7" ]; then
     travis-sphinx --source=docs build
 
     # push if we have a token and this isn't a pr build
-    [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ ! -z "${GH_TOKEN}" ] && travis-sphinx deploy
+    if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ ! -z "${GH_TOKEN}" ]; then
+        travis-sphinx deploy
+    fi
 fi

--- a/build.sh
+++ b/build.sh
@@ -18,11 +18,11 @@ if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
     fi
 fi
 
-# only build docs on py2.7, non-pr builds
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && \
-   [ "${TRAVIS_PYTHON_VERSION}" = "2.7" ] && \
-   [ ! -z "${GH_TOKEN}" ]; then
+# only build docs on py3.6
+if [ "${TRAVIS_PYTHON_VERSION}" = "3.6" ]; then
     pip install travis-sphinx
     travis-sphinx --source=docs build
-    travis-sphinx deploy
+
+    # push if we have a token and this isn't a pr build
+    [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ ! -z "${GH_TOKEN}" ] && travis-sphinx deploy
 fi

--- a/build.sh
+++ b/build.sh
@@ -18,8 +18,8 @@ if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
     fi
 fi
 
-# only build docs on py3.6
-if [ "${TRAVIS_PYTHON_VERSION}" = "3.6" ]; then
+# only build docs on py2.7
+if [ "${TRAVIS_PYTHON_VERSION}" = "2.7" ]; then
     pip install travis-sphinx
     travis-sphinx --source=docs build
 

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -392,7 +392,7 @@ class DynaModel(object):
                 obj[k] = getattr(self, k)
             except AttributeError:
                 pass
-        return obj
+        return self.Schema.dynamorm_validate(obj)
 
     def save(self, **kwargs):
         """Save this instance to the table

--- a/dynamorm/types/_marshmallow.py
+++ b/dynamorm/types/_marshmallow.py
@@ -27,9 +27,9 @@ class Model(Schema, BaseModel):
     @classmethod
     def dynamorm_validate(cls, obj, partial=False, native=False):
         if native:
-            data, errors = cls(partial=partial).dump(obj)
-        else:
             data, errors = cls().load(obj, partial=partial)
+        else:
+            data, errors = cls(partial=partial).dump(obj)
         if errors:
             raise ValidationError(obj, cls.__name__, errors)
         return data

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.2.1',
+    version='0.2.2',
     description='DynamORM is a Python object relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 def TestModel():
     """Provides a test model"""
 
-    if 'marshmallow' in (os.getenv('SERIALIZATION_PKG') or ''):
+    if os.environ.get('SERIALIZATION_PKG', '').startswith('marshmallow'):
         from marshmallow import fields
 
         class DynamoTimestamp(fields.DateTime):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import os
 
@@ -37,6 +38,7 @@ def TestModel():
                 count = fields.Integer()
                 child = fields.Dict()
                 things = fields.List(fields.String())
+                when = fields.DateTime()
 
             def business_logic(self):
                 return 'http://art.lawver.net/funny/internet.jpg?foo={foo}&bar={bar}'.format(
@@ -68,6 +70,7 @@ def TestModel():
                 count = types.IntType()
                 child = compound.DictType(types.StringType)
                 things = compound.ListType(types.BaseType)
+                when = types.DateTimeType()
 
             def business_logic(self):
                 return 'http://art.lawver.net/funny/internet.jpg?foo={foo}&bar={bar}'.format(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,11 +4,9 @@ import pytest
 from dynamorm.model import DynaModel
 from dynamorm.exceptions import InvalidSchemaField, MissingTableAttribute, DynaModelException
 if 'marshmallow' in (os.getenv('SERIALIZATION_PKG') or ''):
-    from marshmallow.fields import String
-    from marshmallow.fields import Number
+    from marshmallow.fields import String, Number, DateTime
 else:
-    from schematics.types import StringType as String
-    from schematics.types import IntType as Number
+    from schematics.types import StringType as String, IntType as Number, DateTimeType as DateTime
 
 
 def test_missing_inner_classes():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,9 +4,9 @@ import pytest
 from dynamorm.model import DynaModel
 from dynamorm.exceptions import InvalidSchemaField, MissingTableAttribute, DynaModelException
 if 'marshmallow' in (os.getenv('SERIALIZATION_PKG') or ''):
-    from marshmallow.fields import String, Number, DateTime
+    from marshmallow.fields import String, Number
 else:
-    from schematics.types import StringType as String, IntType as Number, DateTimeType as DateTime
+    from schematics.types import StringType as String, IntType as Number
 
 
 def test_missing_inner_classes():

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -432,8 +432,6 @@ def test_consistent_read(TestModel, TestModel_entries, dynamo_local):
 def test_native_types(TestModel, TestModel_table, dynamo_local):
     DT = datetime.datetime(2017, 7, 28, 16, 18, 15, 48, tzinfo=dateutil.tz.tzutc())
 
-    # XXX THIS IS NOT REALLY WHAT WE WANT, WE NEED SOME TESTS WITH OUR VERSIONTYPE
-
-    TestModel.put({"foo": "first", "bar": "one", "baz": "lol", "count": 123, "when": DT})
+    TestModel.put({"foo": "first", "bar": "one", "baz": "lol", "count": 123, "when": DT, "created": DT})
     model = TestModel.get(foo='first', bar='one')
     assert model.when == DT

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -53,6 +53,9 @@ def test_schema_change(TestModel, TestModel_table, dynamo_local):
 
 def test_put_invalid_schema(TestModel, TestModel_table, dynamo_local):
     """Putting an invalid schema should raise a ``ValidationError``."""
+    if os.environ['SERIALIZATION_PKG'] == 'marshmallow':
+        pytest.skip('Marshmallow does marshalling and not validation when serializing')
+
     with pytest.raises(ValidationError):
         TestModel.put({"foo": [1], "bar": '10'})
 
@@ -256,6 +259,9 @@ def test_update_conditions(TestModel, TestModel_entries, dynamo_local):
 
 
 def test_update_validation(TestModel, TestModel_entries, dynamo_local):
+    if os.environ['SERIALIZATION_PKG'] == 'marshmallow':
+        pytest.skip('Marshmallow does marshalling and not validation when serializing')
+
     with pytest.raises(ValidationError):
         TestModel.update_item(
             # our hash & range key -- matches current

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -12,6 +12,10 @@ from dynamorm import Q
 from dynamorm.exceptions import HashKeyExists, InvalidSchemaField, ValidationError, ConditionFailed
 
 
+def is_marshmallow():
+    return os.environ.get('SERIALIZATION_PKG', '').startswith('marshmallow')
+
+
 def test_table_creation_deletion(TestModel, dynamo_local):
     """Creating, detecting and deleting tables should work"""
     assert not TestModel.Table.exists
@@ -53,7 +57,7 @@ def test_schema_change(TestModel, TestModel_table, dynamo_local):
 
 def test_put_invalid_schema(TestModel, TestModel_table, dynamo_local):
     """Putting an invalid schema should raise a ``ValidationError``."""
-    if os.environ.get('SERIALIZATION_PKG').startswith('marshmallow'):
+    if is_marshmallow():
         pytest.skip('Marshmallow does marshalling and not validation when serializing')
 
     with pytest.raises(ValidationError):
@@ -259,7 +263,7 @@ def test_update_conditions(TestModel, TestModel_entries, dynamo_local):
 
 
 def test_update_validation(TestModel, TestModel_entries, dynamo_local):
-    if os.environ.get('SERIALIZATION_PKG').startswith('marshmallow'):
+    if is_marshmallow():
         pytest.skip('Marshmallow does marshalling and not validation when serializing')
 
     with pytest.raises(ValidationError):
@@ -305,7 +309,7 @@ def test_update_expressions(TestModel, TestModel_entries, dynamo_local):
     two.update(child={'foo': 'bar'})
     assert two.child == {'foo': 'bar'}
 
-    if 'marshmallow' in (os.getenv('SERIALIZATION_PKG') or ''):
+    if is_marshmallow():
         with pytest.raises(AttributeError):
             assert two.things is None
     else:
@@ -328,7 +332,7 @@ def test_update_expressions(TestModel, TestModel_entries, dynamo_local):
     six = TestModel(foo='sixth', bar='six', baz='baz')
     six.save()
 
-    if 'marshmallow' in (os.getenv('SERIALIZATION_PKG') or ''):
+    if is_marshmallow():
         with pytest.raises(AttributeError):
             assert six.count is None
     else:

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -435,3 +435,6 @@ def test_native_types(TestModel, TestModel_table, dynamo_local):
     TestModel.put({"foo": "first", "bar": "one", "baz": "lol", "count": 123, "when": DT, "created": DT})
     model = TestModel.get(foo='first', bar='one')
     assert model.when == DT
+
+    with pytest.raises(ValidationError):
+        TestModel.put({"foo": "first", "bar": "one", "baz": "lol", "count": 123, "when": DT, "created": {'foo': 1}})

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -53,7 +53,7 @@ def test_schema_change(TestModel, TestModel_table, dynamo_local):
 
 def test_put_invalid_schema(TestModel, TestModel_table, dynamo_local):
     """Putting an invalid schema should raise a ``ValidationError``."""
-    if os.environ['SERIALIZATION_PKG'] == 'marshmallow':
+    if os.environ.get('SERIALIZATION_PKG') == 'marshmallow':
         pytest.skip('Marshmallow does marshalling and not validation when serializing')
 
     with pytest.raises(ValidationError):
@@ -259,7 +259,7 @@ def test_update_conditions(TestModel, TestModel_entries, dynamo_local):
 
 
 def test_update_validation(TestModel, TestModel_entries, dynamo_local):
-    if os.environ['SERIALIZATION_PKG'] == 'marshmallow':
+    if os.environ.get('SERIALIZATION_PKG') == 'marshmallow':
         pytest.skip('Marshmallow does marshalling and not validation when serializing')
 
     with pytest.raises(ValidationError):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,4 +1,6 @@
 """These tests require dynamo local running"""
+import datetime
+import dateutil.tz
 import os
 
 from decimal import Decimal
@@ -425,3 +427,13 @@ def test_consistent_read(TestModel, TestModel_entries, dynamo_local):
 
     test_model = TestModel.get(foo='a', bar='b', consistent=True)
     assert test_model.count == 200
+
+
+def test_native_types(TestModel, TestModel_table, dynamo_local):
+    DT = datetime.datetime(2017, 7, 28, 16, 18, 15, 48, tzinfo=dateutil.tz.tzutc())
+
+    # XXX THIS IS NOT REALLY WHAT WE WANT, WE NEED SOME TESTS WITH OUR VERSIONTYPE
+
+    TestModel.put({"foo": "first", "bar": "one", "baz": "lol", "count": 123, "when": DT})
+    model = TestModel.get(foo='first', bar='one')
+    assert model.when == DT

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -53,7 +53,7 @@ def test_schema_change(TestModel, TestModel_table, dynamo_local):
 
 def test_put_invalid_schema(TestModel, TestModel_table, dynamo_local):
     """Putting an invalid schema should raise a ``ValidationError``."""
-    if os.environ.get('SERIALIZATION_PKG') == 'marshmallow':
+    if os.environ.get('SERIALIZATION_PKG').startswith('marshmallow'):
         pytest.skip('Marshmallow does marshalling and not validation when serializing')
 
     with pytest.raises(ValidationError):
@@ -259,7 +259,7 @@ def test_update_conditions(TestModel, TestModel_entries, dynamo_local):
 
 
 def test_update_validation(TestModel, TestModel_entries, dynamo_local):
-    if os.environ.get('SERIALIZATION_PKG') == 'marshmallow':
+    if os.environ.get('SERIALIZATION_PKG').startswith('marshmallow'):
         pytest.skip('Marshmallow does marshalling and not validation when serializing')
 
     with pytest.raises(ValidationError):


### PR DESCRIPTION
#19 was a little hasty.  After merge it was noticed that while `.put` and other class methods used `dynamorm_validate`, `.save` didn't.

While augmenting `.save` it was realized that we need some more testing around custom types that mutate their values.

This PR addresses those things.