### PR TITLE
Normalize keys in Model to support transformations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.2.4',
+    version='0.2.5',
     description='DynamORM is a Python object relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',


### PR DESCRIPTION
This PR adds key normalization to Model operations.  If a Key has transformative properties this ensures the value that goes to Dynamo is the transformed version.