### PR TITLE
Add support for secondary indexes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,9 +137,8 @@ TODO
 
 These are broken down by milestone release.
 
-0.3.0
+0.4.0
 -----
-* Indexes -- Currently there is no support for indexes.
 * Partial updates on ``save()``
 
 1.0.0

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Example
 
 .. code-block:: python
 
-    from dynamorm import DynaModel
+    from dynamorm import DynaModel, GlobalIndex, ProjectAll
 
     # In this example we'll use Marshmallow, but you can also use Schematics too!
     # You can see that you have to import the schema library yourself, it is not abstracted at all
@@ -61,6 +61,13 @@ Example
             hash_key = 'isbn'
             read = 25
             write = 5
+
+        class ByAuthor(GlobalIndex):
+            name = 'by-author'
+            hash_key = 'author'
+            read = 25
+            write = 5
+            projection = ProjectAll()
 
         # Define our data schema, each property here will become a property on instances of the Book class
         class Schema:
@@ -108,6 +115,9 @@ Example
     # Scan based on attributes
     Book.scan(author="Mr. Bar")
     Book.scan(author__ne="Mr. Bar")
+
+    # Query based on indexes
+    Book.ByAuthor.query(author="Mr. Bar")
 
 
 Documentation

--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,7 @@ These are broken down by milestone release.
 0.4.0
 -----
 * Partial updates on ``save()``
+* Auto-scaling capacity
 
 1.0.0
 -----

--- a/README.rst
+++ b/README.rst
@@ -130,18 +130,3 @@ https://nerdwalletoss.github.io/dynamorm/
 
 The ``tests/`` also contain the most complete documentation on how to actually use the library, so you are encouraged to
 read through them to really familiarize yourself with some of the more advanced concepts and use cases.
-
-
-TODO
-====
-
-These are broken down by milestone release.
-
-0.4.0
------
-* Partial updates on ``save()``
-* Auto-scaling capacity
-
-1.0.0
------
-* Schema Migrations

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,3 +17,15 @@ DynamORM API
 --------------------
 .. automodule:: dynamorm.table
     :members:
+
+
+``dynamorm.exceptions``
+-------------------------
+.. automodule:: dynamorm.exceptions
+    :members:
+
+
+``dynamorm.local``
+--------------------
+.. automodule:: dynamorm.local
+    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,7 +144,7 @@ html_theme = 'alabaster'
 #
 html_theme_options = {
     'description': u'Python object relation mapping library for Amazon\'s DynamoDB service.<br />',
-    'github_user': 'NerdWallet',
+    'github_user': 'NerdWalletOSS',
     'github_repo': 'DynamORM',
     'github_banner': True,
     'github_type': 'star',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ Example
 
 .. code-block:: python
 
-    from dynamorm import DynaModel
+    from dynamorm import DynaModel, GlobalIndex, ProjectAll
 
     # In this example we'll use Marshmallow
     # You can see that you have to import the schema library yourself, it is not abstracted at all
@@ -41,6 +41,13 @@ Example
             hash_key = 'isbn'
             read = 25
             write = 5
+
+        class ByAuthor(GlobalIndex):
+            name = 'by-author'
+            hash_key = 'author'
+            read = 25
+            write = 5
+            projection = ProjectAll()
 
         # Define our data schema, each property here will become a property on instances of the Book class
         class Schema:
@@ -85,6 +92,8 @@ Example
     Book.scan(author="Mr. Bar")
     Book.scan(author__ne="Mr. Bar")
 
+    # Query based on indexes
+    Book.ByAuthor.query(author="Mr. Bar")
 
 Contents
 --------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -162,3 +162,7 @@ Scanning works exactly the same as querying: comparison operators are specified 
     # Scan based on attributes
     Book.scan(author="Mr. Bar")
     Book.scan(author__ne="Mr. Bar")
+
+
+Indexes
+~~~~~~~

--- a/dynamorm/__init__.py
+++ b/dynamorm/__init__.py
@@ -1,9 +1,9 @@
-"""The base module namespace simply imports ``DynaModel`` from ``dynamorm.model`` so that you can:
+"""The base module namespace simply imports the most frequently used objects to simplify imports in clients:
 
 .. code-block:: python
 
     from dynamorm import DynaModel
 
 """
-from .model import DynaModel  # noqa
+from .model import DynaModel, GlobalIndex, LocalIndex, ProjectAll, ProjectKeys, ProjectInclude  # noqa
 from .table import Q  # noqa

--- a/dynamorm/exceptions.py
+++ b/dynamorm/exceptions.py
@@ -58,3 +58,7 @@ class HashKeyExists(DynamoTableException):
 
 class ConditionFailed(DynamoTableException):
     """A condition check failed"""
+
+
+class TableNotActive(DynamoTableException):
+    """The table is not ACTIVE, and you do not want to wait"""

--- a/dynamorm/exceptions.py
+++ b/dynamorm/exceptions.py
@@ -3,8 +3,13 @@ import logging
 log = logging.getLogger(__name__)
 
 
+# --- Base exception ---
+class DynamoException(Exception):
+    """Base exception for all DynamORM raised exceptions"""
+
+
 # --- Schema exceptions ---
-class DynaModelException(Exception):
+class DynaModelException(DynamoException):
     """Base exception for DynaModel problems"""
 
 
@@ -30,6 +35,7 @@ class ValidationError(DynaModelException):
 
 
 # --- Table exceptions ---
+
 class DynamoTableException(Exception):
     """Base exception class for all DynamoTable errors"""
 

--- a/dynamorm/exceptions.py
+++ b/dynamorm/exceptions.py
@@ -36,7 +36,7 @@ class ValidationError(DynaModelException):
 
 # --- Table exceptions ---
 
-class DynamoTableException(Exception):
+class DynamoTableException(DynamoException):
     """Base exception class for all DynamoTable errors"""
 
 

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -101,7 +101,7 @@ class DynaModelMeta(type):
         # Put the instantiated indexes back into our attrs.  We instantiate the Index class that's in the attrs and
         # provide the actual Index object from our table as the parameter.
         for name, klass in six.iteritems(indexes):
-            index = klass(model, model.Table.indexes[name])
+            index = klass(model, model.Table.indexes[klass.name])
             setattr(model, name, index)
 
         # give the Schema and Table objects a reference back to the model

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -496,3 +496,23 @@ class DynaModel(object):
         self._add_hash_key_values(delete_item_kwargs)
 
         return self.Table.delete_item(**delete_item_kwargs)
+
+
+class LocalIndex(object):
+    pass
+
+class GlobalIndex(object):
+    pass
+
+class Projection(object):
+    pass
+
+class ProjectAll(Projection):
+    pass
+
+class ProjectKeys(Projection):
+    pass
+
+class ProjectInclude(Projection):
+    def __init__(self, *include):
+        self.include = include

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -519,17 +519,27 @@ class Index(object):
         self.model = model
         self.index = index
 
-    def query(self, **kwargs):
-        """Execute a query on our index based on our keys
+    def query(self, query_kwargs=None, **kwargs):
+        """Execute a query on this index
 
         See DynaModel.query for documentation on how to pass query arguments.
         """
-        return self.model.query(
-            query_kwargs={
-                'IndexName': self.index.name,
-            },
-            **kwargs
-        )
+        try:
+            query_kwargs['IndexName'] = self.index.name
+        except TypeError:
+            query_kwargs = {'IndexName': self.index.name}
+        return self.model.query(query_kwargs=query_kwargs, **kwargs)
+
+    def scan(self, scan_kwargs=None, **kwargs):
+        """Execute a scan on this index
+
+        See DynaModel.scan for documentation on how to pass scan arguments.
+        """
+        try:
+            scan_kwargs['IndexName'] = self.index.name
+        except TypeError:
+            scan_kwargs = {'IndexName': self.index.name}
+        return self.model.scan(scan_kwargs=scan_kwargs, **kwargs)
 
 
 class LocalIndex(Index):

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -122,7 +122,8 @@ class DynamoIndex3(DynamoCommon3):
         self.schema = schema
         self.validate_attrs()
 
-    def as_args(self):
+    @property
+    def index_args(self):
         if self.projection.__class__.__name__ == 'ProjectAll':
             projection = {
                 'ProjectionType': 'ALL',
@@ -139,12 +140,11 @@ class DynamoIndex3(DynamoCommon3):
         else:
             raise RuntimeError("Unknown projection mode!")
 
-        args = {
+        return {
             'IndexName': self.name,
             'KeySchema': self.key_schema,
             'Projection': projection,
         }
-        return args
 
 
 class DynamoLocalIndex3(DynamoIndex3):
@@ -154,8 +154,9 @@ class DynamoLocalIndex3(DynamoIndex3):
 class DynamoGlobalIndex3(DynamoIndex3):
     ARG_KEY = 'GlobalSecondaryIndexes'
 
-    def as_args(self):
-        args = super(DynamoGlobalIndex3, self).as_args()
+    @property
+    def index_args(self):
+        args = super(DynamoGlobalIndex3, self).index_args
         args['ProvisionedThroughput'] = self.provisioned_throughput
         return args
 
@@ -278,7 +279,7 @@ class DynamoTable3(DynamoCommon3):
 
         index_args = collections.defaultdict(list)
         for index in six.itervalues(self.indexes):
-            index_args[index.ARG_KEY].append(index.as_args())
+            index_args[index.ARG_KEY].append(index.index_args)
 
         table = self.resource.create_table(
             TableName=self.name,

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -206,6 +206,7 @@ class DynamoTable3(DynamoCommon3):
         """Return an appropriate AttributeDefinitions, based on our key attributes and the schema object"""
         seen = []
         defs = []
+
         def add_to_defs(name):
             if name in seen:
                 return

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -22,6 +22,20 @@ write      True      int   The provisioned write throughput.
 =========  ========  ====  ===========
 
 
+Indexes
+-------
+
+Like the ``Table`` definition, Indexes are also inner classes on ``DynaModel`` definitions, and they require the same
+data model with one extra field.
+
+==========  ========  ======  ===========
+Attribute   Required  Type    Description
+==========  ========  ======  ===========
+projection  True      object  An instance of of :class:`dynamorm.model.ProjectAll`, :class:`dynamorm.model.ProjectKeys`,
+                              or :class:`dynamorm.model.ProjectInclude`
+
+=========  ========  ====  ===========
+
 """
 
 import collections

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -251,7 +251,7 @@ class DynamoTable3(DynamoCommon3):
         """Return an appropriate AttributeDefinitions, based on our key attributes and the schema object"""
         defs = []
 
-        def add_to_defs(name):
+        for name in self.all_attribute_fields:
             dynamorm_field = self.schema.dynamorm_fields()[name]
             field_type = self.schema.field_to_dynamo_type(dynamorm_field)
 
@@ -259,9 +259,6 @@ class DynamoTable3(DynamoCommon3):
                 'AttributeName': name,
                 'AttributeType': field_type,
             })
-
-        for field in self.all_attribute_fields:
-            add_to_defs(field)
 
         return defs
 

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -393,7 +393,6 @@ class DynamoTable3(DynamoCommon3):
             do_update(ProvisionedThroughput=self.provisioned_throughput)
             return self.update_table()
 
-
         # Now for the global indexes, turn the data strucutre into a real dictionary so we can look things up by name
         # Along the way we'll delete any indexes that are no longer defined
         existing_indexes = {}

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -34,7 +34,7 @@ Attribute   Required  Type    Description
 projection  True      object  An instance of of :class:`dynamorm.model.ProjectAll`, :class:`dynamorm.model.ProjectKeys`,
                               or :class:`dynamorm.model.ProjectInclude`
 
-=========  ========  ====  ===========
+==========  ========  ======  ===========
 
 """
 

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -26,6 +26,7 @@ write      True      int   The provisioned write throughput.
 
 import collections
 import logging
+import warnings
 
 import boto3
 import botocore
@@ -142,6 +143,12 @@ class DynamoTable3(object):
         )
 
     def create(self, wait=True):
+        """DEPRECATED -- shim"""
+        warnings.warn("DynamoTable3.create has been deprecated, please use DynamoTable3.create_table",
+                      DeprecationWarning)
+        return self.create_table(wait=wait)
+
+    def create_table(self, wait=True):
         """Create a new table based on our attributes
 
         :param bool wait: If set to True, the default, this call will block until the table is created

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.2.5',
+    version='0.3.1',
     description='DynamORM is a Python object relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',
@@ -17,9 +17,9 @@ setup(
         'boto3>=1.3,<2.0',
         'six',
     ],
-    packages=find_packages('.', exclude=['tests', 'docs']),
+    packages=find_packages('.', exclude=['tests', 'docs', 'build']),
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,11 @@ from dynamorm import local
 log = logging.getLogger(__name__)
 
 
+@pytest.fixture(scope='session', autouse=True)
+def setup_logging():
+    logging.basicConfig(level=logging.INFO)
+
+
 @pytest.fixture(scope='session')
 def TestModel():
     """Provides a test model"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import time
 
 import pytest
 
-from dynamorm import DynaModel  # , LocalIndex, GlobalIndex
+from dynamorm import DynaModel, GlobalIndex, LocalIndex, ProjectAll, ProjectKeys, ProjectInclude
 from dynamorm import local
 
 log = logging.getLogger(__name__)
@@ -45,12 +45,27 @@ def TestModel():
                 range_key = 'bar'
                 read = 5
                 write = 5
+            
+            class ByDate(LocalIndex):
+                name = 'by_date'
+                hash_key = 'foo'
+                range_key = 'when'
+                projection = ProjectKeys()
 
-                """
-                class Bazillions(LocalIndex):
-                    read = 5
-                    write = 5
-                """
+            class Bazzy(GlobalIndex):
+                name = 'bazzy'
+                hash_key = 'baz'
+                read = 5
+                write = 5
+                projection = ProjectAll()
+
+            class County(GlobalIndex):
+                name = 'county'
+                hash_key = 'count'
+                range_key = 'foo'
+                read = 5
+                write = 5
+                projection = ProjectInclude('bar')
 
             class Schema:
                 foo = fields.String(required=True)
@@ -96,11 +111,27 @@ def TestModel():
                 read = 5
                 write = 5
 
-                """
-                class Bazillions(LocalIndex):
-                    read = 5
-                    write = 5
-                """
+            class ByDate(LocalIndex):
+                name = 'by_date'
+                hash_key = 'foo'
+                range_key = 'when'
+                projection = ProjectKeys()
+
+            class Bazzy(GlobalIndex):
+                name = 'bazzy'
+                hash_key = 'baz'
+                read = 5
+                write = 5
+                projection = ProjectAll()
+
+            class County(GlobalIndex):
+                name = 'county'
+                hash_key = 'count'
+                range_key = 'foo'
+                read = 5
+                write = 5
+                projection = ProjectInclude('bar')
+
 
             class Schema:
                 foo = types.StringType(required=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,12 +60,12 @@ def TestModel():
                 projection = ProjectAll()
 
             class ByBaz(GlobalIndex):
-                name = 'county'
+                name = 'baz'
                 hash_key = 'baz'
                 range_key = 'bar'
                 read = 5
                 write = 5
-                projection = ProjectInclude('bar')
+                projection = ProjectInclude('count')
 
             class Schema:
                 foo = fields.String(required=True)
@@ -125,12 +125,12 @@ def TestModel():
                 projection = ProjectAll()
 
             class ByBaz(GlobalIndex):
-                name = 'county'
+                name = 'baz'
                 hash_key = 'baz'
                 range_key = 'bar'
                 read = 5
                 write = 5
-                projection = ProjectInclude('bar')
+                projection = ProjectInclude('count')
 
             class Schema:
                 foo = types.StringType(required=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,17 +52,17 @@ def TestModel():
                 range_key = 'when'
                 projection = ProjectKeys()
 
-            class Bazzy(GlobalIndex):
-                name = 'bazzy'
-                hash_key = 'baz'
+            class ByBar(GlobalIndex):
+                name = 'bar'
+                hash_key = 'bar'
                 read = 5
                 write = 5
                 projection = ProjectAll()
 
-            class County(GlobalIndex):
+            class ByBaz(GlobalIndex):
                 name = 'county'
-                hash_key = 'count'
-                range_key = 'foo'
+                hash_key = 'baz'
+                range_key = 'bar'
                 read = 5
                 write = 5
                 projection = ProjectInclude('bar')
@@ -117,18 +117,17 @@ def TestModel():
                 range_key = 'when'
                 projection = ProjectKeys()
 
-            class Bazzy(GlobalIndex):
-                name = 'bazzy'
-                hash_key = 'baz'
-                range_key = 'bar'
+            class ByBar(GlobalIndex):
+                name = 'bar'
+                hash_key = 'bar'
                 read = 5
                 write = 5
                 projection = ProjectAll()
 
-            class County(GlobalIndex):
+            class ByBaz(GlobalIndex):
                 name = 'county'
-                hash_key = 'count'
-                range_key = 'foo'
+                hash_key = 'baz'
+                range_key = 'bar'
                 read = 5
                 write = 5
                 projection = ProjectInclude('bar')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def TestModel():
                 range_key = 'bar'
                 read = 5
                 write = 5
-            
+
             class ByDate(LocalIndex):
                 name = 'by_date'
                 hash_key = 'foo'
@@ -120,6 +120,7 @@ def TestModel():
             class Bazzy(GlobalIndex):
                 name = 'bazzy'
                 hash_key = 'baz'
+                range_key = 'bar'
                 read = 5
                 write = 5
                 projection = ProjectAll()
@@ -131,7 +132,6 @@ def TestModel():
                 read = 5
                 write = 5
                 projection = ProjectInclude('bar')
-
 
             class Schema:
                 foo = types.StringType(required=True)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -167,8 +167,8 @@ def test_index_setup():
 
     model = Model(foo='hi', bar='there')
 
-    assert 'Index' in model.Table.indexes
-    assert model.Index.index is model.Table.indexes['Index']
+    assert 'test-idx' in model.Table.indexes
+    assert model.Index.index is model.Table.indexes['test-idx']
     assert model.Index.index.table is model.Table
 
     assert model.Index.index.schema is model.Schema

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -181,7 +181,7 @@ def test_invalid_indexes():
     """Ensure validation happens for indexes"""
     for idx in (GlobalIndex, LocalIndex):
         with pytest.raises(MissingTableAttribute):
-            class Model(DynaModel):
+            class Model1(DynaModel):
                 class Table:
                     name = 'table'
                     hash_key = 'foo'
@@ -200,7 +200,7 @@ def test_invalid_indexes():
                     bar = String(required=True)
 
         with pytest.raises(MissingTableAttribute):
-            class Model(DynaModel):
+            class Model2(DynaModel):
                 class Table:
                     name = 'table'
                     hash_key = 'foo'
@@ -219,7 +219,7 @@ def test_invalid_indexes():
                     bar = String(required=True)
 
         with pytest.raises(InvalidSchemaField):
-            class Model(DynaModel):
+            class Model3(DynaModel):
                 class Table:
                     name = 'table'
                     hash_key = 'foo'
@@ -239,7 +239,7 @@ def test_invalid_indexes():
                     bar = String(required=True)
 
         with pytest.raises(InvalidSchemaField):
-            class Model(DynaModel):
+            class Model4(DynaModel):
                 class Table:
                     name = 'table'
                     hash_key = 'foo'

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -72,7 +72,7 @@ def test_table_create_validation():
             class Schema:
                 foo = String(required=True)
 
-        Model.Table.create()
+        Model.Table.create_table()
 
     with pytest.raises(MissingTableAttribute):
         class Model(DynaModel):
@@ -84,7 +84,7 @@ def test_table_create_validation():
             class Schema:
                 foo = String(required=True)
 
-        Model.Table.create()
+        Model.Table.create_table()
 
     with pytest.raises(MissingTableAttribute):
         class Model(DynaModel):
@@ -95,7 +95,7 @@ def test_table_create_validation():
             class Schema:
                 foo = String(required=True)
 
-        Model.Table.create()
+        Model.Table.create_table()
 
 
 def test_invalid_hash_key():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -337,3 +337,6 @@ def test_update_table(dynamo_local):
     # updating to v2 result in 1 change
     # * deleting index 1
     assert TableV3.Table.update_table() == 1
+
+    # should now be a no-op
+    assert TableV3.Table.update_table() == 0

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -173,8 +173,8 @@ def test_index_setup():
 
     assert model.Index.index.schema is model.Schema
 
-    # this gets automatically set during initialization, as an optional parameter
-    assert model.Index.read is None
+    # this gets automatically set during initialization, since read is an optional parameter
+    assert model.Index.index.read is None
 
 
 def test_invalid_indexes():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -257,3 +257,83 @@ def test_invalid_indexes():
                 class Schema:
                     foo = String(required=True)
                     bar = String(required=True)
+
+
+def test_update_table(dynamo_local):
+    class TableV1(DynaModel):
+        class Table:
+            name = 'table'
+            hash_key = 'foo'
+            range_key = 'bar'
+            read = 5
+            write = 5
+
+        class Schema:
+            foo = String(required=True)
+            bar = String(required=True)
+            baz = String(required=True)
+            bbq = String(required=True)
+
+    class TableV2(DynaModel):
+        class Table:
+            name = 'table'
+            hash_key = 'foo'
+            range_key = 'bar'
+            read = 10
+            write = 10
+
+        class Index1(GlobalIndex):
+            name = 'index1'
+            hash_key = 'baz'
+            range_key = 'bar'
+            projection = ProjectAll()
+            read = 5
+            write = 5
+
+        class Index2(GlobalIndex):
+            name = 'index2'
+            hash_key = 'bbq'
+            range_key = 'bar'
+            projection = ProjectAll()
+            read = 5
+            write = 5
+
+        class Schema:
+            foo = String(required=True)
+            bar = String(required=True)
+            baz = String(required=True)
+            bbq = String(required=True)
+
+    class TableV3(DynaModel):
+        class Table:
+            name = 'table'
+            hash_key = 'foo'
+            range_key = 'bar'
+            read = 10
+            write = 10
+
+        class Index2(GlobalIndex):
+            name = 'index2'
+            hash_key = 'bbq'
+            range_key = 'bar'
+            projection = ProjectAll()
+            read = 5
+            write = 5
+
+        class Schema:
+            foo = String(required=True)
+            bar = String(required=True)
+            baz = String(required=True)
+            bbq = String(required=True)
+
+    TableV1.Table.create_table()
+
+    # updating to v2 should result in 3 changes
+    # * changing throughput
+    # * adding index1
+    # * adding index2
+    assert TableV2.Table.update_table() == 3
+
+    # updating to v2 result in 1 change
+    # * deleting index 1
+    assert TableV3.Table.update_table() == 1

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -472,3 +472,7 @@ def test_native_types(TestModel, TestModel_table, dynamo_local):
 
     with pytest.raises(ValidationError):
         TestModel.put({"foo": "first", "bar": "one", "baz": "lol", "count": 123, "when": DT, "created": {'foo': 1}})
+
+
+def test_indexes(TestModel, TestModel_entries, dynamo_local):
+    assert True

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -483,7 +483,11 @@ def test_indexes_query(TestModel, TestModel_entries, dynamo_local):
 
     # we project count into the ByBaz index, but not when
     assert results[0].count == 111
-    assert not hasattr(results[0], 'when')
+
+    if is_marshmallow():
+        assert not hasattr(results[0], 'when')
+    else:
+        assert results[0].when is None
 
 
 def test_indexes_scan(TestModel, TestModel_entries, dynamo_local):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -19,7 +19,7 @@ def is_marshmallow():
 def test_table_creation_deletion(TestModel, dynamo_local):
     """Creating, detecting and deleting tables should work"""
     assert not TestModel.Table.exists
-    assert TestModel.Table.create()
+    assert TestModel.Table.create_table()
     assert TestModel.Table.exists
     assert TestModel.Table.delete()
     assert not TestModel.Table.exists

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -489,7 +489,14 @@ def test_indexes_query(TestModel, TestModel_entries, dynamo_local):
     else:
         assert results[0].when is None
 
+    # ByBar only has a hash_key not a range key
+    results = list(TestModel.ByBar.query(bar='three'))
+    assert len(results) == 1
+
 
 def test_indexes_scan(TestModel, TestModel_entries, dynamo_local):
+    results = list(TestModel.ByBaz.scan())
+    assert len(results) == 3
+
     results = list(TestModel.ByBar.scan())
     assert len(results) == 3

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -474,9 +474,18 @@ def test_native_types(TestModel, TestModel_table, dynamo_local):
         TestModel.put({"foo": "first", "bar": "one", "baz": "lol", "count": 123, "when": DT, "created": {'foo': 1}})
 
 
-def test_indexes(TestModel, TestModel_entries, dynamo_local):
+def test_indexes_query(TestModel, TestModel_entries, dynamo_local):
+    results = list(TestModel.ByBaz.query(baz='bbq'))
+    assert len(results) == 2
+
     results = list(TestModel.ByBaz.query(baz='bbq', bar='one'))
     assert len(results) == 1
 
-    results = list(TestModel.ByBaz.query(baz='bbq'))
-    assert len(results) == 2
+    # we project count into the ByBaz index, but not when
+    assert results[0].count == 111
+    assert not hasattr(results[0], 'when')
+
+
+def test_indexes_scan(TestModel, TestModel_entries, dynamo_local):
+    results = list(TestModel.ByBar.scan())
+    assert len(results) == 3

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -475,4 +475,8 @@ def test_native_types(TestModel, TestModel_table, dynamo_local):
 
 
 def test_indexes(TestModel, TestModel_entries, dynamo_local):
-    assert True
+    results = list(TestModel.ByBaz.query(baz='bbq', bar='one'))
+    assert len(results) == 1
+
+    results = list(TestModel.ByBaz.query(baz='bbq'))
+    assert len(results) == 2


### PR DESCRIPTION
This PR adds support for local & global secondary indexes.

Conceptually, the implementation mirrors the Model -> Table relationship.  Inside of the `.model` namespace new objects for index types and projection types provide the API that users leverage.  Inside of the `.table` namespace other corresponding new objects map the API from the model namespace to boto3.

```
class Book(DynaModel):
    class Table:
        name = 'prod-books'
        hash_key = 'isbn'
        read = 25
        write = 5

    class ByAuthor(GlobalIndex):
        name = 'by-author'
        hash_key = 'author'
        read = 25
        write = 5
        projection = ProjectAll()

    class Schema:
        ...
```

Indexes are added to models as inner classes, just like the main table definition, but they must extend from either an index type (i.e. `GlobalIndex`) and they must specify a projection type (i.e. `ProjectAll()`).  You can define as many indexes as you want.

During metaclass processing when the table object is created, we also turn the index definitions into instantiated objects that are used to query or scan the index (there is no get item functionality for indexes -- https://stackoverflow.com/a/43733229/877024):

```
Book.ByAuthor.query(...)
Book.ByAuthor.scan(...)
```

Query & scan processing work EXACTLY the same as on the table.  In fact, they're both just a shim through to the table query/scan that also happens to add `IndexName` to the kwargs.