### PR TITLE
Support partial updates on save

### DIFF
--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -420,6 +420,12 @@ class DynaModel(object):
     def save(self, partial=False, **kwargs):
         """Save this instance to the table
 
+        :param bool partial: When False the whole document will be ``.put`` to the table.  When True only values that
+                             have changed since the document was loaded will sent to the table via an ``.update``.
+        :param \*\*kwargs: When partial is False these are passed through to the put method on the table.  When partial
+                           is True these become the kwargs for update_item.  See ``.put`` & ``.update`` for more
+                           details.
+
         The attributes on the item go through validation, so this may raise :class:`ValidationError`.
         """
         if not partial:
@@ -555,14 +561,32 @@ class Projection(object):
 
 
 class ProjectAll(Projection):
+    """Project all attributes from the Table into the Index
+
+    Documents loaded using this projection will be fully validated by the schema.
+    """
     partial = False
 
 
 class ProjectKeys(Projection):
+    """Project the keys from the Table into the Index.
+
+    Documents loaded using this projection will be partially validated by the schema.
+    """
     partial = True
 
 
 class ProjectInclude(Projection):
+    """Project the specified attributes into the Index.
+
+    Documents loaded using this projection will be partially validated by the schema.
+
+    .. code-block:: python
+
+        class ByAuthor(GlobalIndex):
+            ...
+            projection = ProjectInclude('some_attr', 'other_attr')
+    """
     partial = True
 
     def __init__(self, *include):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.3.2',
+    version='0.3.3',
     description='DynamORM is a Python object relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -382,8 +382,9 @@ def test_sparse_indexes(dynamo_local):
 def test_partial_save(TestModel, TestModel_entries, dynamo_local):
     def get_first():
         first = TestModel.get(foo='first', bar='one')
-        first.Table.put = MagicMock()
-        first.Table.update = MagicMock()
+        first.Table = MagicMock()
+        first.Table.hash_key = 'foo'
+        first.Table.range_key = 'bar'
         return first
 
     # the first time to a non-partial save and put should be called


### PR DESCRIPTION
This PR gives the `.save` method a `partial=` keyword, that if True will do a `.update` instead of `.put` on the table and only send the values that have changed.

This resolves #25

🍹 