### PR TITLE
Implement model signals

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ fi
 # only build docs on py2.7
 if [ "${TRAVIS_PYTHON_VERSION}" = "2.7" ]; then
     pip install travis-sphinx
-    travis-sphinx -s docs build
+    travis-sphinx build --source docs
 
     # push if we have a token and this isn't a pr build
     if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ ! -z "${GH_TOKEN}" ]; then

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ fi
 # only build docs on py2.7
 if [ "${TRAVIS_PYTHON_VERSION}" = "2.7" ]; then
     pip install travis-sphinx
-    travis-sphinx build
+    travis-sphinx -s docs build
 
     # push if we have a token and this isn't a pr build
     if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ ! -z "${GH_TOKEN}" ]; then

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ fi
 # only build docs on py2.7
 if [ "${TRAVIS_PYTHON_VERSION}" = "2.7" ]; then
     pip install travis-sphinx
-    travis-sphinx --source=docs build
+    travis-sphinx build
 
     # push if we have a token and this isn't a pr build
     if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ ! -z "${GH_TOKEN}" ]; then

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,6 +17,25 @@ DynamORM API
 .. automodule:: dynamorm.signals
     :members:
 
+.. autodata:: model_prepared
+    :annotation:
+.. autodata:: pre_init
+    :annotation:
+.. autodata:: post_init
+    :annotation:
+.. autodata:: pre_save
+    :annotation:
+.. autodata:: post_save
+    :annotation:
+.. autodata:: pre_update
+    :annotation:
+.. autodata:: post_update
+    :annotation:
+.. autodata:: pre_delete
+    :annotation:
+.. autodata:: post_delete
+    :annotation:
+
 
 ``dynamorm.table``
 --------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,6 +12,11 @@ DynamORM API
 .. automodule:: dynamorm.model
     :members:
 
+``dynamorm.signals``
+--------------------
+.. automodule:: dynamorm.signals
+    :members:
+
 
 ``dynamorm.table``
 --------------------

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -442,9 +442,9 @@ class DynaModel(object):
         The attributes on the item go through validation, so this may raise :class:`ValidationError`.
         """
         if not partial:
-            pre_save.send(self.__class__, instance=self, partial=partial, put_kwargs=kwargs)
+            pre_save.send(self.__class__, instance=self, put_kwargs=kwargs)
             resp = self.put(self.to_dict(), **kwargs)
-            post_save.send(self.__class__, instance=self, partial=partial, put_kwargs=kwargs)
+            post_save.send(self.__class__, instance=self, put_kwargs=kwargs)
             return resp
 
         # Collect the fields to updated based on what's changed

--- a/dynamorm/signals.py
+++ b/dynamorm/signals.py
@@ -1,3 +1,23 @@
+"""Signals provide a way for applications to loosely couple themselves and respond to different life cycle events.
+
+The `blinker`_ library provides the low-level signal implementation.
+
+To use the signals you ``connect`` a receiver function to the signals you're interested in:
+
+.. code-block:: python
+
+    from dynamorm.signals import post_save
+
+    def post_save_receiver(sender, instance, partial, put_kwargs):
+        log.info("Received post_save signal from model %s for instance %s", sender, instance)
+
+    post_save.connect(post_save_receiver)
+
+See the `blinker`_ documentation for more details.
+
+.. _blinker: https://pythonhosted.org/blinker/
+"""
+
 from blinker import signal
 
 model_prepared = signal(

--- a/dynamorm/signals.py
+++ b/dynamorm/signals.py
@@ -1,0 +1,95 @@
+from blinker import signal
+
+model_prepared = signal(
+    'dynamorm.model_prepared',
+    doc='''Sent whenever a model class has been prepared by the metaclass.
+
+    :param: sender: The model class that is now prepared for use.
+    '''
+)
+
+pre_init = signal(
+    'dynamorm.pre_init',
+    doc='''Sent during model instantiation, before processing the raw data.
+
+    :param: sender: The model class.
+    :param: instance: The model instance.
+    :param: bool partial: True if this is a partial instantiation, not all data may be present.
+    :param: dict raw: The raw data to be processed by the model schema.
+    '''
+)
+
+post_init = signal(
+    'dynamorm.post_init',
+    doc='''Sent once model instantiation is complete and all raw data has been processed.
+
+    :param: sender: The model class.
+    :param: instance: The model instance.
+    :param: bool partial: True if this is a partial instantiation, not all data may be present.
+    :param: dict raw: The raw data to be processed by the model schema.
+    '''
+)
+
+pre_save = signal(
+    'dynamorm.pre_save',
+    doc='''Sent before saving (via put) model instances.
+
+    :param: sender: The model class.
+    :param: instance: The model instance.
+    :param: bool partial: True if this is a partial instantiation, not all data may be present.
+    :param: dict put_kwargs: A dict of the kwargs being sent to the table put method.
+    '''
+)
+
+post_save = signal(
+    'dynamorm.post_save',
+    doc='''Sent after saving (via put) model instances.
+
+    :param: sender: The model class.
+    :param: instance: The model instance.
+    :param: bool partial: True if this is a partial instantiation, not all data may be present.
+    :param: dict put_kwargs: A dict of the kwargs being sent to the table put method.
+    '''
+)
+
+pre_update = signal(
+    'dynamorm.pre_update',
+    doc='''Sent before saving (via update) model instances.
+
+    :param: sender: The model class.
+    :param: instance: The model instance.
+    :param: dict conditions: The conditions for the update to succeed.
+    :param: dict update_item_kwargs: A dict of the kwargs being sent to the table put method.
+    :param: dict updates: The fields to update.
+    '''
+)
+
+post_update = signal(
+    'dynamorm.post_update',
+    doc='''Sent after saving (via update) model instances.
+
+    :param: sender: The model class.
+    :param: instance: The model instance.
+    :param: dict conditions: The conditions for the update to succeed.
+    :param: dict update_item_kwargs: A dict of the kwargs being sent to the table put method.
+    :param: dict updates: The fields to update.
+    '''
+)
+
+pre_delete = signal(
+    'dynamorm.pre_delete',
+    doc='''Sent before deleting model instances.
+
+    :param: sender: The model class.
+    :param: instance: The model instance.
+    '''
+)
+
+post_delete = signal(
+    'dynamorm.post_delete',
+    doc='''Sent after deleting model instances.
+
+    :param: sender: The model class.
+    :param: instance: The deleted model instance.
+    '''
+)

--- a/dynamorm/signals.py
+++ b/dynamorm/signals.py
@@ -56,7 +56,6 @@ pre_save = signal(
 
     :param: sender: The model class.
     :param: instance: The model instance.
-    :param: bool partial: True if this is a partial instantiation, not all data may be present.
     :param: dict put_kwargs: A dict of the kwargs being sent to the table put method.
     '''
 )
@@ -67,7 +66,6 @@ post_save = signal(
 
     :param: sender: The model class.
     :param: instance: The model instance.
-    :param: bool partial: True if this is a partial instantiation, not all data may be present.
     :param: dict put_kwargs: A dict of the kwargs being sent to the table put method.
     '''
 )

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -31,8 +31,8 @@ data model with one extra field.
 ==========  ========  ======  ===========
 Attribute   Required  Type    Description
 ==========  ========  ======  ===========
-projection  True      object  An instance of of :class:`dynamorm.model.ProjectAll`, :class:`dynamorm.model.ProjectKeys`,
-                              or :class:`dynamorm.model.ProjectInclude`
+projection  True      object  An instance of of :class:`dynamorm.model.ProjectAll`,
+                              :class:`dynamorm.model.ProjectKeys`, or :class:`dynamorm.model.ProjectInclude`
 
 ==========  ========  ======  ===========
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.3.4',
+    version='0.4.1',
     description='DynamORM is a Python object relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',
@@ -14,6 +14,7 @@ setup(
     license='Apache License Version 2.0',
 
     install_requires=[
+        'blinker>=1.4,<2.0',
         'boto3>=1.3,<2.0',
         'six',
     ],

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,31 @@
+import os
+
+from dynamorm.model import DynaModel
+from dynamorm.signals import model_prepared
+
+if 'marshmallow' in (os.getenv('SERIALIZATION_PKG') or ''):
+    from marshmallow.fields import String
+else:
+    from schematics.types import StringType as String
+
+
+def test_model_prepared():
+    def receiver(model):
+        receiver.calls.append(model)
+    receiver.calls = []
+
+    model_prepared.connect(receiver)
+
+    assert len(receiver.calls) == 0
+
+    class SillyModel(DynaModel):
+        class Table:
+            name = 'silly'
+            hash_key = 'silly'
+            read = 1
+            write = 1
+
+        class Schema:
+            silly = String(required=True)
+
+    assert receiver.calls == [SillyModel]


### PR DESCRIPTION
This PR adds signals, via [blinker](https://pythonhosted.org/blinker/).

* model_prepared - Sent when the metaclass prepares a model class
* pre_init / post_init - Sent during the initialization of a model instance
* pre_save / post_save - Sent during a put of a model instance
* pre_update / post_update - Sent during an update of a model instance
* pre_delete / post_delete - Sent when deleting a model instance

This was originally added in #33, but I wanted to pull it out to a separate PR since I think #33 is going the wrong direction and I'll likely start over.