### PR TITLE
Ensure inherited fields are pulled up for schematics

### DIFF
--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -73,6 +73,18 @@ class DynaModelMeta(type):
                     break
                 elif module_name.startswith('schematics.'):
                     from .types._schematics import Schema
+
+                    # Pull all of our fields up onto the main schema, obeying MRO
+                    # This is done to ensure that "mixin" class fields get properly declared for Schematics
+                    def pull_up_fields(cls):
+                        for base in reversed(cls.__bases__):
+                            for k, v in six.iteritems(base.__dict__):
+                                if isinstance(v, Schema.base_field_type()):
+                                    setattr(attrs['Schema'], k, v)
+                            pull_up_fields(base)
+
+                    pull_up_fields(attrs['Schema'])
+
                     break
             else:
                 raise DynaModelException("Unknown Schema definitions, we couldn't find any supported fields/types")

--- a/dynamorm/types/_marshmallow.py
+++ b/dynamorm/types/_marshmallow.py
@@ -30,3 +30,7 @@ class Schema(MarshmallowSchema, DynamORMSchema):
         if errors:
             raise ValidationError(obj, cls.__name__, errors)
         return data
+
+    @staticmethod
+    def base_field_type():
+        return fields.Field

--- a/dynamorm/types/_schematics.py
+++ b/dynamorm/types/_schematics.py
@@ -32,3 +32,7 @@ class Schema(SchematicsModel, DynamORMSchema):
             return inst.to_native()
         else:
             return inst.to_primitive()
+
+    @staticmethod
+    def base_field_type():
+        return types.BaseType

--- a/dynamorm/types/base.py
+++ b/dynamorm/types/base.py
@@ -29,3 +29,8 @@ class DynamORMSchema(object):
         On validation failure, this should raise ``dynamorm.exc.ValidationError``.
         """
         raise NotImplementedError('{0} class must implement dynamallow_validate'.format(cls.__name__))
+
+    @staticmethod
+    def base_field_type():
+        """Returns the class that all fields in the schema will inherit from"""
+        raise NotImplementedError('{0} class must implement base_field_type'.format(cls.__name__))

--- a/dynamorm/types/base.py
+++ b/dynamorm/types/base.py
@@ -33,4 +33,4 @@ class DynamORMSchema(object):
     @staticmethod
     def base_field_type():
         """Returns the class that all fields in the schema will inherit from"""
-        raise NotImplementedError('{0} class must implement base_field_type'.format(cls.__name__))
+        raise NotImplementedError('Child class must implement base_field_type')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.4.1',
+    version='0.4.2',
     description='DynamORM is a Python object relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -447,6 +447,7 @@ def test_explicit_schema_parents():
     with pytest.raises(ValidationError):
         Model(foo='foo', baz='baz', bar='not bar')
 
+
 def test_schema_parents_mro():
     """Inner Schema classes should obey MRO (to test our schematics field pull up)"""
     class MixinTwo(object):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -428,6 +428,7 @@ def test_explicit_schema_parents():
     assert Model.Schema.is_mixin is True
     assert list(sorted(Model.Schema.dynamorm_fields().keys())) == ['bar', 'baz', 'bbq', 'foo']
 
+
 def test_schema_parents_mro():
     """Inner Schema classes should obey MRO (to test our schematics field pull up)"""
     class MixinTwo(object):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -426,8 +426,7 @@ def test_explicit_schema_parents():
             baz = String(required=True)
 
     assert Model.Schema.is_mixin is True
-    assert 'bar' in Model.Schema.dynamorm_fields()
-    assert 'bbq' in Model.Schema.dynamorm_fields()
+    assert list(sorted(Model.Schema.dynamorm_fields().keys())) == ['bar', 'baz', 'bbq', 'foo']
 
 def test_schema_parents_mro():
     """Inner Schema classes should obey MRO (to test our schematics field pull up)"""

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -407,8 +407,12 @@ def test_partial_save(TestModel, TestModel_entries, dynamo_local):
 
 def test_explicit_schema_parents():
     """Inner Schema classes should be able to have explicit parents"""
-    class Mixin(object):
+    class SuperMixin(object):
+        bbq = String()
+
+    class Mixin(SuperMixin):
         is_mixin = True
+        bar = String()
 
     class Model(DynaModel):
         class Table:
@@ -422,4 +426,27 @@ def test_explicit_schema_parents():
             baz = String(required=True)
 
     assert Model.Schema.is_mixin is True
-    assert Model.Schema.dynamorm_fields()
+    assert 'bar' in Model.Schema.dynamorm_fields()
+    assert 'bbq' in Model.Schema.dynamorm_fields()
+
+def test_schema_parents_mro():
+    """Inner Schema classes should obey MRO (to test our schematics field pull up)"""
+    class MixinTwo(object):
+        bar = Number()
+
+    class MixinOne(object):
+        bar = String()
+
+    class Model(DynaModel):
+        class Table:
+            name = 'table'
+            hash_key = 'foo'
+            read = 1
+            write = 1
+
+        class Schema(MixinOne, MixinTwo):
+            foo = Number(required=True)
+            baz = String(required=True)
+
+    assert 'bar' in Model.Schema.dynamorm_fields()
+    assert isinstance(Model.Schema.dynamorm_fields()['bar'], String)


### PR DESCRIPTION
@ahollenbach & @robby-bryant discovered that when using Schematics with mixins on the inner `Schema` simple attributes (like `is_mixin`) were being properly exposed but anything that was a field was not.  This has to do with how the Schematics metaclass is processing the base classes.

This PR "pulls up" the fields to the base schema attrs when using Schematics and ensures that we respect MRO.