### PR TITLE
Fix broken partial save

### DIFF
--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -455,7 +455,9 @@ class DynaModel(object):
         """
         if not partial:
             pre_save.send(self.__class__, instance=self, put_kwargs=kwargs)
-            resp = self.put(self.to_dict(), **kwargs)
+            as_dict = self.to_dict()
+            resp = self.put(as_dict, **kwargs)
+            self._validated_data = as_dict
             post_save.send(self.__class__, instance=self, put_kwargs=kwargs)
             return resp
 
@@ -463,7 +465,7 @@ class DynaModel(object):
         # XXX: Deeply nested data will still put the whole top-most object that has changed
         # TODO: Support the __ syntax to do deeply nested updates
         updates = dict(
-            (k, v)
+            (k, getattr(self, k))
             for k, v in six.iteritems(self._validated_data)
             if getattr(self, k) != v
         )
@@ -536,6 +538,7 @@ class DynaModel(object):
         # update our local attrs to match what we updated
         for key, val in six.iteritems(resp['Attributes']):
             setattr(self, key, val)
+            self._validated_data[key] = val
 
         post_update.send(self.__class__, instance=self, conditions=conditions, update_item_kwargs=update_item_kwargs,
                          updates=kwargs)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.4.2',
+    version='0.4.3',
     description='DynamORM is a Python object relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -385,10 +385,7 @@ def test_partial_save(TestModel, TestModel_entries, dynamo_local):
     def get_first():
         first = TestModel.get(foo='first', bar='one')
         first.put = MagicMock()
-        first.update_item = MagicMock(side_effect=[
-            {'Attributes': {'baz': 'changed'}},
-            {'Attributes': {'bbq': 10}},
-        ])
+        first.update_item = MagicMock()
         return first
 
     # the first time to a non-partial save and put should be called
@@ -400,7 +397,9 @@ def test_partial_save(TestModel, TestModel_entries, dynamo_local):
     # put should not be called, and update should only be called once dispite save being called twice
     first = get_first()
     first.save(partial=True)
+
     first.baz = 'changed'
+    first.update_item.return_value = {'Attributes': {'baz': 'changed'}}
     first.save(partial=True)
     first.put.assert_not_called()
 
@@ -419,6 +418,7 @@ def test_partial_save(TestModel, TestModel_entries, dynamo_local):
 
     # do it again, and just count should be sent
     first.count = 999
+    first.update_item.return_value = {'Attributes': {'count': 999}}
     first.save(partial=True)
     first.put.assert_not_called()
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -394,7 +394,6 @@ def test_partial_save(TestModel, TestModel_entries, dynamo_local):
     # the first time to a non-partial save and put should be called
     first = get_first()
     first.save()
-    first.put.assert_called_once()
     first.update_item.assert_not_called()
 
     # next do a partial save without any changed and again with a change


### PR DESCRIPTION
As correctly pointed out here: https://github.com/NerdWalletOSS/dynamorm/pull/30#discussion_r151822196

The current partial save implementation is broken, due to a failure to properly mock things out combined with invalid assertions:

```
assert first.Table.update.called_with(...)
```

This will *ALWAYS* pass.  The reason?  `called_with` is not a attr/method on a `MagicMock` object, and what happens with you call a missing attr on a `MagicMock`?  You get another `MagicMock` back.  So, the `assert` always passed since the mock object wasn't `None`.  🤦‍♂️ 