### PR TITLE
Allow for per-table boto3 resource config

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -31,14 +31,17 @@ Configuring the Boto3 resource
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The above example is relying on the files ``~/.aws/credentials`` & ``~/.aws/config`` to provide access information and
-region selection.  If you would instead like to configure these properties at run-time you can do this by passing the
-configuration to the ``Table.get_resource`` method on any of your models (once you've defined them -- below).
+region selection.  You can provide explicitly configuration for boto3 sessions and resources as part of your ``Table``
+definition.
 
 .. code-block:: python
 
-    MyModel.Table.get_resource(
-        region_name='us-east-2'
-    )
+
+    class MyModel(DynaModel):
+        class Table:
+            resource_kwargs = {
+                'region_name': 'us-east-2'
+            }
 
 The `boto3 resource`_ for DynamoDB is **globally** shared between all models, so you only need to call this once on a
 single model and all models will use the configured resource.  Anything you pass to the ``Table.get_resource`` call is

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -31,19 +31,29 @@ Configuring the Boto3 resource
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The above example is relying on the files ``~/.aws/credentials`` & ``~/.aws/config`` to provide access information and
-region selection.  You can provide explicit configuration for boto3 sessions and resources as part of your ``Table``
-definition.
+region selection.  You can provide explicit configuration for `boto3 sessions`_ and `boto3 resources`_ as part of your
+``Table`` definition.
+
+For example, if you develop against a local dynamo service your models make look something like:
 
 .. code-block:: python
 
 
     class MyModel(DynaModel):
         class Table:
-            resource_kwargs = {
+            session_kwargs = {
                 'region_name': 'us-east-2'
             }
+            resource_kwargs = {
+                'endpoint_url': 'http://localhost:33333'
+            }
 
-.. _boto3 resource: http://boto3.readthedocs.io/en/latest/reference/services/dynamodb.html#service-resource
+
+You would obviously want the session and resource configuration to come from some sort of configuration provider that
+could provide the correct options depending on where your application is being run.
+
+.. _boto3 sessions: http://boto3.readthedocs.io/en/latest/reference/core/session.html
+.. _boto3 resources: http://boto3.readthedocs.io/en/latest/reference/services/dynamodb.html#service-resource
 .. _Flask: http://flask.pocoo.org/
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -43,34 +43,6 @@ definition.
                 'region_name': 'us-east-2'
             }
 
-The `boto3 resource`_ for DynamoDB is **globally** shared between all models, so you only need to call this once on a
-single model and all models will use the configured resource.  Anything you pass to the ``Table.get_resource`` call is
-passed directly into the ``boto3.resource('dynamodb')`` call, so anything supported by the underlying resource is also
-supported here.
-
-Calling ``Table.get_resource`` is often done as part of your framework startup / initialization.  For example, if you
-were using DynamORM with `Flask`_ you would call it when you create the instance of your "app":
-
-.. code-block:: python
-
-    import json
-
-    from flask import Flask
-    from myapp.models import MyModel
-
-    # Create the WSGI app
-    app = Flask(__name__)
-
-    # Configure Dynamo access
-    MyModel.Table.get_resource(
-        region_name='us-east-2'
-    )
-
-    @app.route("/")
-    def hello():
-        return json.dumps(MyModel.scan())
-
-
 .. _boto3 resource: http://boto3.readthedocs.io/en/latest/reference/services/dynamodb.html#service-resource
 .. _Flask: http://flask.pocoo.org/
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -34,7 +34,7 @@ The above example is relying on the files ``~/.aws/credentials`` & ``~/.aws/conf
 region selection.  You can provide explicit configuration for `boto3 sessions`_ and `boto3 resources`_ as part of your
 ``Table`` definition.
 
-For example, if you develop against a local dynamo service your models make look something like:
+For example, if you develop against a local dynamo service your models may look something like:
 
 .. code-block:: python
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -31,7 +31,7 @@ Configuring the Boto3 resource
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The above example is relying on the files ``~/.aws/credentials`` & ``~/.aws/config`` to provide access information and
-region selection.  You can provide explicitly configuration for boto3 sessions and resources as part of your ``Table``
+region selection.  You can provide explicit configuration for boto3 sessions and resources as part of your ``Table``
 definition.
 
 .. code-block:: python

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -111,7 +111,7 @@ class DynaModelMeta(type):
         if should_transform('Table'):
             TableClass = type(
                 '{name}Table'.format(name=name),
-                (DynamoTable3,),
+                (DynamoTable3,) + attrs['Table'].__bases__,
                 dict(attrs['Table'].__dict__)
             )
             attrs['Table'] = TableClass(schema=attrs['Schema'], indexes=indexes)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.5.3',
+    version='0.6.0',
     description='DynamORM is a Python object & relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.6.0',
+    version='0.7.0',
     description='DynamORM is a Python object & relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 from dynamorm import DynaModel, GlobalIndex, LocalIndex, ProjectAll, ProjectKeys, ProjectInclude
 from dynamorm import local
+from dynamorm.table import DynamoTable3
 
 log = logging.getLogger(__name__)
 
@@ -226,11 +227,11 @@ def TestModelTwo_table(request, TestModelTwo, dynamo_local):
 
 
 @pytest.fixture(scope='session')
-def dynamo_local(request, TestModel):
+def dynamo_local(request):
     """Connect to a local dynamo instance"""
     dynamo_local_dir = os.environ.get('DYNAMO_LOCAL', 'build/dynamo-local')
     dynamo_local_ = local.DynamoLocal(dynamo_local_dir)
-    TestModel.Table.get_resource(
+    DynamoTable3.get_resource(
         aws_access_key_id="anything",
         aws_secret_access_key="anything",
         region_name="us-west-2",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -523,3 +523,41 @@ def test_schema_parents_mro():
 
     assert 'bar' in Model.Schema.dynamorm_fields()
     assert isinstance(Model.Schema.dynamorm_fields()['bar'], String)
+
+
+def test_table_config(TestModel, dynamo_local):
+    class MyModel(DynaModel):
+        class Table:
+            name = 'mymodel'
+            hash_key = 'foo'
+            read = 10
+            write = 10
+
+            resource_kwargs = {
+                'region_name': 'us-east-2'
+            }
+
+        class Schema:
+            foo = String(required=True)
+
+    class OtherModel(DynaModel):
+        class Table:
+            name = 'othermodel'
+            hash_key = 'foo'
+            read = 10
+            write = 10
+
+        class Schema:
+            foo = String(required=True)
+
+    # dynamo_local sets up the default table config to point to us-west-2
+    # So any models, like TestModel, that don't specify a config end up pointing there
+    assert TestModel.Table.resource.meta.client.meta.region_name == 'us-west-2'
+
+    # Our first model above has explicit resource kwargs, as such it should get a different resource with our explicitly
+    # configured region name
+    assert MyModel.Table.resource.meta.client.meta.region_name == 'us-east-2'
+
+    # Tables that share the same resource kwargs share the same resources
+    assert MyModel.Table.resource is not TestModel.Table.resource
+    assert OtherModel.Table.resource is TestModel.Table.resource


### PR DESCRIPTION
This is one of the longest standing todo items for this project, and was the cause of a small outage today following a deploy of a service using this library.

This PR allows for inner `Table` classes to specify explicit `session_kwargs` to the boto3 session constructor, or `resource_kwargs` to the boto3 resource constructor.

It also pulls the resource up from the base common object to the base table object and changes the base index object so that it just uses the resource from its associated table.

Fixes #7 

FYI @ahollenbach @robby-bryant