### PR TITLE
Allow field subclassing

### DIFF
--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -73,16 +73,16 @@ class DynaModelMeta(type):
         # To allow both schematics and marshmallow to be installed and select the correct model we peek inside of the
         # dict and see if the item comes from either of them and lazily import our local Model implementation.
         if should_transform('Schema'):
-            for schema_item in six.itervalues(attrs['Schema'].__dict__):
-                try:
-                    module_name = schema_item.__module__
-                except AttributeError:
-                    continue
+            def module_name_startswith_in_mro(obj, name):
+                for klass in obj.__class__.__mro__:
+                    if klass.__module__.startswith(name):
+                        return True
 
-                if module_name.startswith('marshmallow.'):
+            for schema_item in six.itervalues(attrs['Schema'].__dict__):
+                if module_name_startswith_in_mro(schema_item, 'marshmallow.'):
                     from .types._marshmallow import Schema
                     break
-                elif module_name.startswith('schematics.'):
+                elif module_name_startswith_in_mro(schema_item, 'schematics.'):
                     from .types._schematics import Schema
 
                     # Pull all of our fields up onto the main schema, obeying MRO

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.7.0',
+    version='0.7.1',
     description='DynamORM is a Python object & relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -596,4 +596,4 @@ def test_field_subclassing():
         class Schema:
             foo = SubSubclassedString(required=True)
 
-    assert MyModel.Schema.fields['foo']
+    assert isinstance(MyModel.Schema.dynamorm_fields()['foo'], String)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -577,3 +577,23 @@ def test_table_config(TestModel, dynamo_local):
     # Tables that share the same resource kwargs share the same resources
     assert MyModel.Table.resource is not TestModel.Table.resource
     assert OtherModel.Table.resource is TestModel.Table.resource
+
+
+def test_field_subclassing():
+    class SubclassedString(String):
+        pass
+
+    class SubSubclassedString(SubclassedString):
+        pass
+
+    class MyModel(DynaModel):
+        class Table:
+            name = 'mymodel'
+            hash_key = 'foo'
+            read = 10
+            write = 10
+
+        class Schema:
+            foo = SubSubclassedString(required=True)
+
+    assert MyModel.Schema.fields['foo']


### PR DESCRIPTION
If a user subclasses a field, to add or extend functionality, the new field cannot be used in our schema because the new fields `__module__` doesn't match our check anymore.

This PR changes the way to determine which library to use by walking the MRO of the field and considering the full chain on inheritance.

FYI @dpnnw 