### PR TITLE
Detect schema library based on loaded modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,6 @@ deploy:
     secure: FcwdP+EvSobBQHBgg3EJJ8A1atMV1kA+5ObICRGV6HAB1ZigUil/8LSeiuDct9/GcQMnPK09U9pQpS5nm/YdqEW4hteIGg0FTcD7qphCUZX3CnP7f+svvXghWX+TfQ4m1BpvC+bShUJ+dI9vrzoh+DY6rxijcNElVvRZTA0DarwPXnFllogBF9G0wJxVbxMsoG5zWWCYeWfKZOojpkk0rCaGnR4Tl/5tnbiS/dSEEXnk60DGJFvW4aXK1CkHPv8wAiRNFKp4AfNL6WXQJcLfaZaj7STcU5AHvOsCFL7ojGKHjz2EkKLTSN+oa9L2nct36ZLv8nbzpDiPqBcteS0sVO40FqsgMp8+Ou6KFK9jIxGf7FuTf6we3f4sVEyaaRAZvmOX4cmieBnqB9YVv+njrYB2O7clJcCG3eypq7y5HelQ0lslzYlpWOvLG9Xo6qL0zUSl2PPgJx179WKncLSa0k/cWgNW9q1h2Vqc0+g64CPh8OjEjEhlmUAHBp/zfUyAMc9hZDlwLOU087R/0X6DznPlfpMO6/5Cb24wW6bU3XVnBteNhJrDj8aoR1lie5hjzldxLi2xngjPwqEHGz9FCx3FXeRKTPuk9aNH1xB+2S42jx42SR4ZiXrPmy06jhrpupnA0qkPsEsQ//5Dw9L/9mVeeQ9tm6PpgJdS2YELDsE=
   on:
     branch: master
+    python: 3.6
+    condition: $SERIALIZATION_PKG = schematics==2.0.1
   distributions: "sdist bdist_wheel"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.7.1',
+    version='0.7.2',
     description='DynamORM is a Python object & relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -586,6 +586,9 @@ def test_field_subclassing():
     class SubSubclassedString(SubclassedString):
         pass
 
+    class Mixin(object):
+        foo = SubSubclassedString(required=True)
+
     class MyModel(DynaModel):
         class Table:
             name = 'mymodel'
@@ -593,7 +596,7 @@ def test_field_subclassing():
             read = 10
             write = 10
 
-        class Schema:
-            foo = SubSubclassedString(required=True)
+        class Schema(Mixin):
+            pass
 
     assert isinstance(MyModel.Schema.dynamorm_fields()['foo'], String)


### PR DESCRIPTION
Continuation of #45, since the use case was actually for when a `Schema` has no declared fields and all fields are inherited.  I've altered the test to cover this use case now.

More importantly, this PR also makes the whole schema library detection much simpler by just looking at what's in `sys.modules` and not trying to inspect any fields.

FYI @dpnnw 