### PR TITLE
Allow updates (and partial saves) to return all values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
   - pypy
 
 env:
-  - SERIALIZATION_PKG="marshmallow==2.13.5"
+  - SERIALIZATION_PKG="marshmallow==2.15.0"
   - SERIALIZATION_PKG="schematics==2.0.1"
 
 install: false

--- a/dynamorm/types/_marshmallow.py
+++ b/dynamorm/types/_marshmallow.py
@@ -1,3 +1,5 @@
+import six
+
 from marshmallow import Schema as MarshmallowSchema
 from marshmallow import fields
 
@@ -29,6 +31,14 @@ class Schema(MarshmallowSchema, DynamORMSchema):
             data, errors = cls(partial=partial).dump(obj)
         if errors:
             raise ValidationError(obj, cls.__name__, errors)
+
+        # When asking for partial native objects (during model init) we want to return None values
+        # This ensures our object has all attributes and we can track partial saves properly
+        if partial and native:
+            for name in six.iterkeys(cls().fields):
+                if name not in data:
+                    data[name] = None
+
         return data
 
     @staticmethod

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.7.2',
+    version='0.7.3',
     description='DynamORM is a Python object & relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -474,11 +474,7 @@ def test_partial_save(TestModel, TestModel_entries, dynamo_local):
 
 def test_partial_save_with_return_all(TestModel, TestModel_entries, dynamo_local):
     model_to_patch = TestModel(foo='first', bar='one', partial=True)
-    if is_marshmallow():
-        with pytest.raises(AttributeError):
-            assert model_to_patch.baz is None
-    else:
-        assert model_to_patch.baz is None
+    assert model_to_patch.baz is None
     model_to_patch.count = 12345
     model_to_patch.save(partial=True, return_all=True)
     assert model_to_patch.baz == 'bbq'

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -11,7 +11,12 @@ from dynamorm.exceptions import (
     ValidationError,
 )
 
-if 'marshmallow' in (os.getenv('SERIALIZATION_PKG') or ''):
+
+def is_marshmallow():
+    return os.environ.get('SERIALIZATION_PKG', '').startswith('marshmallow')
+
+
+if is_marshmallow():
     from marshmallow.fields import String, Integer as Number
     from marshmallow import validates, ValidationError as SchemaValidationError
 else:
@@ -467,6 +472,18 @@ def test_partial_save(TestModel, TestModel_entries, dynamo_local):
     first.update_item.assert_has_calls([baz_update_call, count_update_call])
 
 
+def test_partial_save_with_return_all(TestModel, TestModel_entries, dynamo_local):
+    model_to_patch = TestModel(foo='first', bar='one', partial=True)
+    if is_marshmallow():
+        with pytest.raises(AttributeError):
+            assert model_to_patch.baz is None
+    else:
+        assert model_to_patch.baz is None
+    model_to_patch.count = 12345
+    model_to_patch.save(partial=True, return_all=True)
+    assert model_to_patch.baz == 'bbq'
+
+
 def test_unique_save(TestModel, TestModel_entries, dynamo_local):
     first = TestModel(foo='first', bar='one', baz='uno')
     first.save()
@@ -482,7 +499,7 @@ def test_explicit_schema_parents():
     class SuperMixin(object):
         bbq = String()
 
-    if 'marshmallow' in (os.getenv('SERIALIZATION_PKG') or ''):
+    if is_marshmallow():
         class Mixin(SuperMixin):
             is_mixin = True
             bar = String()

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -506,11 +506,7 @@ def test_indexes_query(TestModel, TestModel_entries, dynamo_local):
 
     # we project count into the ByBaz index, but not when
     assert results[0].count == 111
-
-    if is_marshmallow():
-        assert not hasattr(results[0], 'when')
-    else:
-        assert results[0].when is None
+    assert results[0].when is None
 
     # ByBar only has a hash_key not a range key
     results = list(TestModel.ByBar.query(bar='three'))


### PR DESCRIPTION
This adds a new `return_all` kwarg to both `.save` and `.update` on models.  It only applies to partial saves.

If set to `True` then the call to update item will set `ReturnValues` to `ALL_NEW` instead of `UPDATED_NEW`, in which case the partial model will be fully hydrated with the current state from Dynamo.