### PR TITLE
Allow for dict based botocore configuration

### DIFF
--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -220,6 +220,17 @@ class DynamoTable3(DynamoCommon3):
         for key, val in six.iteritems(cls.resource_kwargs or {}):
             kwargs.setdefault(key, val)
 
+        # allow for dict based resource config that we convert into a botocore Config object
+        # https://botocore.readthedocs.io/en/stable/reference/config.html
+        try:
+            resource_config = kwargs['config']
+        except KeyError:
+            # no 'config' provided in the kwargs
+            pass
+        else:
+            if isinstance(resource_config, dict):
+                kwargs['config'] = botocore.config.Config(**resource_config)
+
         return boto3_session.resource('dynamodb', **kwargs)
 
     @classmethod

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -205,7 +205,7 @@ class DynamoTable3(DynamoCommon3):
     def get_resource(cls, **kwargs):
         """Return the boto3 resource
 
-        If you provide **kwargs here and the class doesn't have any resource_kwargs defined then the ones passed will
+        If you provide kwargs here and the class doesn't have any resource_kwargs defined then the ones passed will
         permanently override the resource_kwargs on the class.
 
         This is useful for bootstrapping test resources against a Dynamo local instance as a call to

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,5 @@ universal=1
 test=pytest
 
 [flake8]
-exclude=./build/*,*.egg-info/*,.eggs/*
+exclude=./build/*,./configs/*,*.egg-info/*,.eggs/*
 max_line_length=160

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.7.4',
+    version='0.7.5',
     description='DynamORM is a Python object & relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -525,11 +525,23 @@ def test_indexes_scan(TestModel, TestModel_entries, dynamo_local):
 
 def test_config():
     class TestTable(DynamoTable3):
-        """get_resource modifies it's class when given kwargs, so we use this to avoid mutating the base class"""
-        pass
+        resource_kwargs = {
+            'config': {
+                'retries': {
+                    'max_attempts': 1
+                }
+            }
+        }
 
-    resource = TestTable.get_resource(config={'retries': {'max_attempts': 1}})
-    assert resource.meta.client.meta.config.retries['max_attempts'] == 3
+    resource = TestTable.get_resource()
+    assert resource.meta.client.meta.config.retries['max_attempts'] == 1
+
+    class BadConfigTable(DynamoTable3):
+        resource_kwargs = {
+            'config': {
+                'foo': True
+            }
+        }
 
     with pytest.raises(botocore.exceptions.InvalidRetryConfigurationError):
-        TestTable.get_resource(config={'foo': True})
+        TestTable.get_resource()

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -10,7 +10,7 @@ import pytest
 
 from dynamorm import Q
 
-from dynanorm.table import DynamoTable3
+from dynamorm.table import DynamoTable3
 from dynamorm.exceptions import HashKeyExists, InvalidSchemaField, ValidationError, ConditionFailed
 
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -526,15 +526,14 @@ def test_indexes_scan(TestModel, TestModel_entries, dynamo_local):
 def test_config():
     class TestTable(DynamoTable3):
         resource_kwargs = {
+            'region_name': 'us-west-2',
             'config': {
-                'retries': {
-                    'max_attempts': 1
-                }
+                'connect_timeout': 1,
             }
         }
 
     resource = TestTable.get_resource()
-    assert resource.meta.client.meta.config.retries['max_attempts'] == 1
+    assert resource.meta.client.meta.config.connect_timeout == 1
 
     class BadConfigTable(DynamoTable3):
         resource_kwargs = {
@@ -543,5 +542,5 @@ def test_config():
             }
         }
 
-    with pytest.raises(botocore.exceptions.InvalidRetryConfigurationError):
-        TestTable.get_resource()
+    with pytest.raises(TypeError):
+        BadConfigTable.get_resource()

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -5,7 +5,6 @@ import os
 
 from decimal import Decimal
 
-import botocore
 import pytest
 
 from dynamorm import Q


### PR DESCRIPTION
Often times configuration systems provide raw dicts (i.e. when loading from JSON) and it's onerous to have to convert this config into `botocore.config.Config` objects manually.

This PR adds support for passing a dict for `config` to `DynamoTable3.get_resource` and we'll convert it into the `botocore.config.Config` object automatically.