### PR TITLE
Ensure we use validated values when updating

### DIFF
--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -285,7 +285,11 @@ class DynaModel(object):
         :params update_item_kwargs: A dict of other kwargs that are passed through to update_item
         :params \*\*kwargs: Includes your hash/range key/val to match on as well as any keys to update
         """
-        cls.Schema.dynamorm_validate(kwargs, partial=True)
+        kwargs.update(dict(
+            (k, v)
+            for k, v in six.iteritems(cls.Schema.dynamorm_validate(kwargs, partial=True))
+            if k in kwargs
+        ))
         kwargs = cls._normalize_keys_in_kwargs(kwargs)
         return cls.Table.update(conditions=conditions, update_item_kwargs=update_item_kwargs, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.7.5',
+    version='0.7.6',
     description='DynamORM is a Python object & relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',


### PR DESCRIPTION
Currently, when doing an update we call validate but then just pass the kwargs through, so we don't actual use the validated & marshaled data.

This PR changes things so that we retain the validated/marshaled value and use its values when calling update_item on the table. 