### PR TITLE
Dpnnw/fix schema changed update return all

### DIFF
--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -580,9 +580,12 @@ class DynaModel(object):
             # update our local attrs to match what we updated
             partial_model = self.new_from_raw(resp['Attributes'], partial=True)
             for key, _ in six.iteritems(resp['Attributes']):
-                val = getattr(partial_model, key)
-                setattr(self, key, val)
-                self._validated_data[key] = val
+                # elsewhere in Dynamorm, models can be created without all fields (non-"strict" mode in Schematics),
+                # so we drop unknown keys here to be consistent
+                if hasattr(partial_model, key):
+                    val = getattr(partial_model, key)
+                    setattr(self, key, val)
+                    self._validated_data[key] = val
 
         post_update.send(self.__class__, instance=self, conditions=conditions, update_item_kwargs=update_item_kwargs,
                          updates=kwargs)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamorm',
-    version='0.7.7',
+    version='0.7.8',
     description='DynamORM is a Python object & relation mapping library for Amazon\'s DynamoDB service.',
     long_description=long_description,
     author='Evan Borgstrom',

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -327,6 +327,22 @@ def test_update_invalid_fields(TestModel, TestModel_entries, dynamo_local):
         )
 
 
+def test_schema_field_removed_update_return_all(TestModel, TestModel_table, dynamo_local):
+    """Simulate a schema change with field removed and make sure we can update the record
+       and return all columns with new schema
+    """
+    data = {'foo': '1', 'bar': '2', 'old_schema_key': 10, 'baz': 'baz'}
+    TestModel.Table.put(data)
+    item = TestModel.get(foo='1', bar='2')
+    item.update(baz='bbs', return_all=True)
+
+    assert item.foo == '1'
+    assert item.bar == '2'
+    assert item.baz == 'bbs'
+    # Old unrecognized column should be dropped
+    assert not hasattr(item, 'old_schema_key')
+
+
 def test_update_expressions(TestModel, TestModel_entries, dynamo_local):
     two = TestModel.get(foo='first', bar='two')
     assert two.child == {'sub': 'two'}


### PR DESCRIPTION
Currently it's not possible to update a table if the
schema is backwards incompatible due to the implicit
strict=True update semantics. This is only affected when
updating a model with return_all=True.