### PR TITLE
fix KeyConditionExpressions for query(id=id).recursive()

### DIFF
--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -671,7 +671,8 @@ class DynamoTable3(DynamoCommon3):
             key_expression = get_expression(key, op, value)
 
             try:
-                query_kwargs['KeyConditionExpression'] = query_kwargs['KeyConditionExpression'] & key_expression
+                if not query_kwargs['KeyConditionExpression'] == key_expression:
+                    query_kwargs['KeyConditionExpression'] = query_kwargs['KeyConditionExpression'] & key_expression
             except (KeyError, TypeError):
                 query_kwargs['KeyConditionExpression'] = key_expression
 


### PR DESCRIPTION
"KeyConditionExpressions must only contain one condition per key"

If you do query(id="id").recursive() you will get KeyConditionExpressions exception as the current logic makes a boto3.dynamodb.conditions.And even if the kwargs and the specified key_expression (query(id=x)) is the same. To resolve this check before creating the AND condition if the two are the same and don't make AND condition if it is.