### PR TITLE
Using serialized values in the call to Table.delete_item()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,9 +82,9 @@ Example
             author = fields.String()
             publisher = fields.String()
 
-            # NOTE: Marshmallow uses the `missing` keyword during deserialization, which occurs when we save
-            # an object to Dynamo and the attr has no value, versus the `default` keyword, which is used when
-            # we load a document from Dynamo and the value doesn't exist or is null.
+            # NOTE: Marshmallow uses the `missing` keyword during deserialization, which occurs when we load
+            # an object from Dynamo and the value doesn't exist or is null, versus the `default` keyword,
+            # which is used when we save a document to Dynamo and the attr has no value.
             year = fields.Number(missing=lambda: datetime.datetime.utcnow().year)
 
 

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -476,7 +476,7 @@ class DynaModel(object):
         hash_dict[self.Table.hash_key] = as_dict[self.Table.hash_key]
         try:
             hash_dict[self.Table.range_key] = as_dict[self.Table.range_key]
-        except (AttributeError, TypeError, ValueError):
+        except (AttributeError, TypeError, KeyError):
             pass
 
     def update(self, conditions=None, update_item_kwargs=None, return_all=False, **kwargs):

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -472,9 +472,10 @@ class DynaModel(object):
     def _add_hash_key_values(self, hash_dict):
         """Mutate a dicitonary to add key: value pair for a hash and (if specified) sort key.
         """
-        hash_dict[self.Table.hash_key] = getattr(self, self.Table.hash_key)
+        as_dict = self.to_dict()
+        hash_dict[self.Table.hash_key] = as_dict[self.Table.hash_key]
         try:
-            hash_dict[self.Table.range_key] = getattr(self, self.Table.range_key)
+            hash_dict[self.Table.range_key] = as_dict[self.Table.range_key]
         except (AttributeError, TypeError):
             pass
 

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -476,7 +476,7 @@ class DynaModel(object):
         hash_dict[self.Table.hash_key] = as_dict[self.Table.hash_key]
         try:
             hash_dict[self.Table.range_key] = as_dict[self.Table.range_key]
-        except (AttributeError, TypeError):
+        except (AttributeError, TypeError, ValueError):
             pass
 
     def update(self, conditions=None, update_item_kwargs=None, return_all=False, **kwargs):


### PR DESCRIPTION
Deletes were failing on types that dynamo doesnt have native conversion support for in boto3.  So we grab the serialized version, and pass that instead.

Issue:
#67 