### PR TITLE
Avoid validating twice when saving Models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,34 +15,34 @@ matrix:
       env: TOXENV=docs
 
     - python: 2.7
-      env: TOXENV=py27-schematics,codecov-py27
+      env: TOXENV=py27-schematics-codecov
     - python: 2.7
-      env: TOXENV=py27-marshmallow,codecov-py27
+      env: TOXENV=py27-marshmallow-codecov
 
     - python: 3.5
-      env: TOXENV=py35-schematics,codecov-py35
+      env: TOXENV=py35-schematics-codecov
     - python: 3.5
-      env: TOXENV=py35-marshmallow,codecov-py35
+      env: TOXENV=py35-marshmallow-codecov
 
     - python: 3.6
-      env: TOXENV=py36-schematics,codecov-py36
+      env: TOXENV=py36-schematics-codecov
     - python: 3.6
-      env: TOXENV=py36-marshmallow,codecov-py36
+      env: TOXENV=py36-marshmallow-codecov
 
     - python: 3.7
-      env: TOXENV=py37-schematics,codecov-py37
+      env: TOXENV=py37-schematics-codecov
     - python: 3.7
-      env: TOXENV=py37-marshmallow,codecov-py37
+      env: TOXENV=py37-marshmallow-codecov
 
     - python: pypy
-      env: TOXENV=pypy2-schematics,codecov-pypy2
+      env: TOXENV=pypy2-schematics-codecov
     - python: pypy
-      env: TOXENV=pypy2-marshmallow,codecov-pypy2
+      env: TOXENV=pypy2-marshmallow-codecov
 
     - python: pypy3
-      env: TOXENV=pypy3-schematics,codecov-pypy3
+      env: TOXENV=pypy3-schematics-codecov
     - python: pypy3
-      env: TOXENV=pypy3-marshmallow,codecov-pypy3
+      env: TOXENV=pypy3-marshmallow-codecov
 
 
 install: pip install tox
@@ -61,7 +61,7 @@ deploy:
     on:
       branch: master
       python: 3.7
-      condition: $TOXENV = py37-marshmallow,codecov-py37
+      condition: $TOXENV = py37-marshmallow-codecov
     distributions: "sdist bdist_wheel"
 
   - provider: pages

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+0.9.9 - 2019.09.30
+##################
+
+* Performance: Avoid validating twice when calling ``.save()`` on a model.
+
 0.9.8 - 2019.09.29
 ##################
 

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -465,9 +465,9 @@ class DynaModel(object):
             pre_save.send(self.__class__, instance=self, put_kwargs=kwargs)
             as_dict = self.to_dict()
             if unique:
-                resp = self.put_unique(as_dict, **kwargs)
+                resp = self.Table.put_unique(as_dict, **kwargs)
             else:
-                resp = self.put(as_dict, **kwargs)
+                resp = self.Table.put(as_dict, **kwargs)
             self._validated_data = as_dict
             post_save.send(self.__class__, instance=self, put_kwargs=kwargs)
             return resp

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as readme_fd:
 
 setup(
     name="dynamorm",
-    version="0.9.8",
+    version="0.9.9",
     description="DynamORM is a Python object & relation mapping library for Amazon's DynamoDB service.",
     long_description=long_description,
     author="Evan Borgstrom",

--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,8 @@ basepython =
 deps =
     pytest
     pytest-mock
-    codecov
 
+    codecov: codecov
     schematics: .[schematics]
     marshmallow: .[marshmallow]
 
@@ -41,6 +41,7 @@ setenv =
 commands =
     schematics: coverage run --source=dynamorm "{envbindir}/pytest" -v -W ignore::schematics.deprecated.SchematicsDeprecationWarning {posargs:tests}
     marshmallow: coverage run --source=dynamorm "{envbindir}/pytest" -v {posargs:tests}
+    codecov: codecov -e TOXENV
 
 
 [testenv:black]
@@ -68,14 +69,3 @@ deps =
 
 commands =
     sphinx-build -b html -d "{envtmpdir}/doctrees" docs docs/_build/html
-
-
-[testenv:codecov]
-skip_install = True
-
-deps =
-    codecov
-
-commands =
-    coverage combine --append
-    codecov -e TOXENV --required


### PR DESCRIPTION
This was originally called out by @MHannila in #69 (apologies for taking so long to address it!)

When you call `.save()` on a Model we call `.to_dict()` on that instance, which in turn does native validation via `.dynamorm_validate()` on the Marshmallow or Schematics backend.

We originally called `self.put()` (or `.put_unique()`) which would re-call `.dynamorm_validate()` on the already validated dictionary.

This PR changes the behavior so that in `.save()` we simply call the put method directly on the table class so we don't incur the second validation call.

### Checklist

- [x] Tests have been written to cover any new or updated functionality
- [x] All tests pass when running `tox` locally
- [x] The documentation in `docs/` has been updated to cover any changes
- [x] The version in `setup.py` has been bumped to the next version -- follow semver!
- [x] Add an entry to `CHANGELOG.rst` has been added

Closes #69 