### PR TITLE
Normalize keys when deleting model instances

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+0.9.10 - 2019.09.30
+###################
+
+* Bug fix: Ensure keys are normalized when calling ``.delete()`` on a model.
+
 0.9.9 - 2019.09.30
 ##################
 

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -487,7 +487,7 @@ class DynaModel(object):
         return self.update(update_item_kwargs=kwargs, return_all=return_all, **updates)
 
     def _add_hash_key_values(self, hash_dict):
-        """Mutate a dicitonary to add key: value pair for a hash and (if specified) sort key.
+        """Mutate a dictionary to add key: value pair for a hash and (if specified) sort key.
         """
         hash_dict[self.Table.hash_key] = getattr(self, self.Table.hash_key)
         try:

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -587,6 +587,7 @@ class DynaModel(object):
         """Delete this record in the table."""
         delete_item_kwargs = {}
         self._add_hash_key_values(delete_item_kwargs)
+        self._normalize_keys_in_kwargs(delete_item_kwargs)
 
         pre_delete.send(self.__class__, instance=self)
         resp = self.Table.delete_item(**delete_item_kwargs)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as readme_fd:
 
 setup(
     name="dynamorm",
-    version="0.9.9",
+    version="0.9.10",
     description="DynamORM is a Python object & relation mapping library for Amazon's DynamoDB service.",
     long_description=long_description,
     author="Evan Borgstrom",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -20,7 +20,11 @@ if is_marshmallow():
     from marshmallow.fields import String, Integer as Number, UUID
     from marshmallow import validates, ValidationError as SchemaValidationError
 else:
-    from schematics.types import StringType as String, IntType as Number, UUIDType as UUID
+    from schematics.types import (
+        StringType as String,
+        IntType as Number,
+        UUIDType as UUID,
+    )
     from schematics.exceptions import ValidationError as SchemaValidationError
 
 try:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -649,7 +649,7 @@ def test_field_subclassing():
 def test_delete_normalized_keys(dynamo_local, request):
     class Model(DynaModel):
         class Table:
-            name = "mymodel"
+            name = "delete_normalized"
             hash_key = "uuid"
             read = 10
             write = 10

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -659,6 +659,8 @@ def test_delete_normalized_keys(dynamo_local, request):
 
     Model(uuid="cc1dea15-c359-455a-a53e-c0a7a31ee022").save()
 
+    # We originally did not normalize keys when calling delete, which would cause this
+    # to fail with: TypeError: Unsupported type "<class 'uuid.UUID'>"
     Model.get(uuid="cc1dea15-c359-455a-a53e-c0a7a31ee022").delete()
 
     assert Model.get(uuid="cc1dea15-c359-455a-a53e-c0a7a31ee022") is None

--- a/tox.ini
+++ b/tox.ini
@@ -39,8 +39,10 @@ setenv =
     marshmallow: SERIALIZATION_PKG=marshmallow
 
 commands =
-    schematics: coverage run --source=dynamorm "{envbindir}/pytest" -v -W ignore::schematics.deprecated.SchematicsDeprecationWarning {posargs:tests}
-    marshmallow: coverage run --source=dynamorm "{envbindir}/pytest" -v {posargs:tests}
+    schematics-!codecov: pytest -v -W ignore::schematics.deprecated.SchematicsDeprecationWarning {posargs:tests}
+    marshmallow-!codecov: pytest -v {posargs:tests}
+    schematics-codecov: coverage run --source=dynamorm "{envbindir}/pytest" -v -W ignore::schematics.deprecated.SchematicsDeprecationWarning {posargs:tests}
+    marshmallow-codecov: coverage run --source=dynamorm "{envbindir}/pytest" -v {posargs:tests}
     codecov: codecov -e TOXENV
 
 


### PR DESCRIPTION
This PR resolves the issue reported by @kimvais in #67 where calling `.delete()` on a Model instance with "complex" keys does not work because the keys are not normalized.

### Checklist

- [x] Tests have been written to cover any new or updated functionality
- [x] All tests pass when running `tox` locally
- [x] The documentation in `docs/` has been updated to cover any changes
- [x] The version in `setup.py` has been bumped to the next version -- follow semver!
- [x] Add an entry to `CHANGELOG.rst` has been added

Closes #68 
Fixes #67 

CC @usethecodeluke