### PR TITLE
Don't mutate original dicts in Table methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+0.9.11 - 2019.09.30
+###################
+
+* Bug fix: Don't mutate dictionaries passed to table methods.
+
+  This caused problems with ``ReadIterator`` objects that called ``.again()`` because the underlying Table object would end up mutating state on the iterator object.
+
 0.9.10 - 2019.09.30
 ###################
 

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -582,7 +582,10 @@ class DynamoTable3(DynamoCommon3):
                 writer.put_item(Item=remove_nones(item))
 
     def update(self, update_item_kwargs=None, conditions=None, **kwargs):
-        update_item_kwargs = update_item_kwargs or {}
+        # copy update_item_kwargs, so that we don't mutate the original later on
+        update_item_kwargs = dict(
+            (k, v) for k, v in six.iteritems(update_item_kwargs or {})
+        )
         conditions = conditions or {}
         update_key = {}
         update_fields = []
@@ -646,7 +649,10 @@ class DynamoTable3(DynamoCommon3):
             raise
 
     def get_batch(self, keys, consistent=False, attrs=None, batch_get_kwargs=None):
-        batch_get_kwargs = batch_get_kwargs or {}
+        # copy batch_get_kwargs, so that we don't mutate the original later on
+        batch_get_kwargs = dict(
+            (k, v) for k, v in six.iteritems(batch_get_kwargs or {})
+        )
 
         batch_get_kwargs["Keys"] = []
         for kwargs in keys:
@@ -679,7 +685,8 @@ class DynamoTable3(DynamoCommon3):
                 break
 
     def get(self, consistent=False, get_item_kwargs=None, **kwargs):
-        get_item_kwargs = get_item_kwargs or {}
+        # copy get_item_kwargs, so that we don't mutate the original later on
+        get_item_kwargs = dict((k, v) for k, v in six.iteritems(get_item_kwargs or {}))
 
         for k, v in six.iteritems(kwargs):
             if k not in self.schema.dynamorm_fields():
@@ -697,7 +704,10 @@ class DynamoTable3(DynamoCommon3):
             return response["Item"]
 
     def query(self, *args, **kwargs):
-        query_kwargs = kwargs.pop("query_kwargs", {})
+        # copy query_kwargs, so that we don't mutate the original later on
+        query_kwargs = dict(
+            (k, v) for k, v in six.iteritems(kwargs.pop("query_kwargs", {}))
+        )
         filter_kwargs = {}
 
         if "IndexName" in query_kwargs:
@@ -747,7 +757,10 @@ class DynamoTable3(DynamoCommon3):
         return self.table.query(**query_kwargs)
 
     def scan(self, *args, **kwargs):
-        scan_kwargs = kwargs.pop("scan_kwargs", None) or {}
+        # copy scan_kwargs, so that we don't mutate the original later on
+        scan_kwargs = dict(
+            (k, v) for k, v in six.iteritems(kwargs.pop("scan_kwargs", {}))
+        )
 
         filter_expression = Q(**kwargs)
         for arg in args:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as readme_fd:
 
 setup(
     name="dynamorm",
-    version="0.9.10",
+    version="0.9.11",
     description="DynamORM is a Python object & relation mapping library for Amazon's DynamoDB service.",
     long_description=long_description,
     author="Evan Borgstrom",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -201,7 +201,7 @@ def TestModel_entries_xlarge(TestModel, TestModel_table):
     """Used with TestModel, creates and deletes the table and populates multiple pages of entries"""
     TestModel.put_batch(
         *[
-            {"foo": str(i), "bar": "baz", "baz": "bat" * 100}
+            {"foo": "first", "bar": str(i), "baz": "bat" * 100}
             for i in range(
                 4000
             )  # 1mb page is roughly 3300 items, so 4000 will be two pages.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -668,3 +668,11 @@ def test_delete_normalized_keys(dynamo_local, request):
     Model.get(uuid="cc1dea15-c359-455a-a53e-c0a7a31ee022").delete()
 
     assert Model.get(uuid="cc1dea15-c359-455a-a53e-c0a7a31ee022") is None
+
+
+def test_query_with_id_and_recursive(TestModel, TestModel_entries_xlarge, dynamo_local):
+    """Ensure that we don't raise a KeyCondition error when our query + recursive returns more than a page
+
+    https://github.com/NerdWalletOSS/dynamorm/pull/63/
+    """
+    assert len(list(TestModel.query(foo="first").recursive())) == 4000

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -388,12 +388,12 @@ def test_scan_iterator(TestModel, TestModel_entries_xlarge, dynamo_local, mocker
     results = ScanIterator(TestModel)
 
     assert TestModel.Table.scan.call_count == 0
-    assert len(list(results)) == 3322
+    assert len(list(results)) == 3299
     assert TestModel.Table.scan.call_count == 1
 
     results = ScanIterator(TestModel).start(results.last)
 
-    assert len(list(results)) == 678
+    assert len(list(results)) == 701
     assert TestModel.Table.scan.call_count == 2
 
 


### PR DESCRIPTION
This was originally reported in #63, however the exact cause wasn't known until I did some debugging today.  The actual cause of #63 is that when `.again()` was called on the `ReadIterator` object for the table query the iterator object stored the query kwargs as `self.dynamo_kwargs` and when the table `.query()` method was called it ended up mutating that dictionary.

This PR changes the behavior of all the table methods so that any of the dictionaries that are accepted are copied rather than used directly to ensure we don't inadvertently mutate something.

FYI @sooslaca 

### Checklist

- [x] Tests have been written to cover any new or updated functionality
- [x] All tests pass when running `tox` locally
- [x] The documentation in `docs/` has been updated to cover any changes
- [x] The version in `setup.py` has been bumped to the next version -- follow semver!
- [x] Add an entry to `CHANGELOG.rst` has been added

Closes #63 