### PR TITLE
Ensure GitHub pages serves our static content

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+0.9.12 - 2019.09.30
+###################
+
+* Ensure GitHub pages serves our static documentation content
+* No functional library changes
+
 0.9.11 - 2019.09.30
 ###################
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as readme_fd:
 
 setup(
     name="dynamorm",
-    version="0.9.11",
+    version="0.9.12",
     description="DynamORM is a Python object & relation mapping library for Amazon's DynamoDB service.",
     long_description=long_description,
     author="Evan Borgstrom",

--- a/tox.ini
+++ b/tox.ini
@@ -71,3 +71,4 @@ deps =
 
 commands =
     sphinx-build -b html -d "{envtmpdir}/doctrees" docs docs/_build/html
+    touch docs/_build/html/.nojekyll


### PR DESCRIPTION
Ever since we switched to using Travis to deploy our docs the static content hasn't shown up.

Turns out that GitHub is trying to process them as Jekyll metadata: https://help.github.com/en/articles/files-that-start-with-an-underscore-are-missing

This PR makes the tox docs build add a `.nojekyll` file to ensure GitHub doesn't run Jekyll on the built docs.
