### PR TITLE
[Bugfix] Ensure full model validation when using schematics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+0.9.14 - 2019.12.13
+###################
+
+* Ensure that ``dynamorm_validate`` actually calls ``schematics`` validation.
+
 0.9.13 - 2019.12.12
 ###################
 

--- a/dynamorm/types/_schematics.py
+++ b/dynamorm/types/_schematics.py
@@ -27,7 +27,7 @@ class Schema(SchematicsModel, DynamORMSchema):
     @classmethod
     def dynamorm_validate(cls, obj, partial=False, native=False):
         try:
-            inst = cls(obj, strict=False, partial=partial)
+            inst = cls(obj, strict=False, partial=partial, validate=True)
         except (SchematicsValidationError, ModelConversionError) as e:
             raise ValidationError(obj, cls.__name__, e.messages)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as readme_fd:
 
 setup(
     name="dynamorm",
-    version="0.9.13",
+    version="0.9.14",
     description="DynamORM is a Python object & relation mapping library for Amazon's DynamoDB service.",
     long_description=long_description,
     author="Evan Borgstrom",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 import time
 
 import pytest
+from dateutil import tz
 
 from dynamorm import (
     DynaModel,
@@ -43,7 +44,9 @@ def TestModel():
 
             def _deserialize(self, value, attr, data, **kwargs):
                 try:
-                    return datetime.datetime.fromtimestamp(float(value) / 1000000)
+                    return datetime.datetime.fromtimestamp(
+                        float(value) / 1000000, tz=tz.tzutc()
+                    )
                 except TypeError:
                     if isinstance(value, datetime.datetime):
                         return value
@@ -108,7 +111,9 @@ def TestModel():
 
             def to_native(self, value, context=None):
                 try:
-                    return datetime.datetime.fromtimestamp(float(value) / 1000000)
+                    return datetime.datetime.fromtimestamp(
+                        float(value) / 1000000, tz=tz.tzutc()
+                    )
                 except TypeError:
                     if isinstance(value, datetime.datetime):
                         return value

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -210,6 +210,49 @@ def test_missing_field_validation():
         )
 
 
+def test_validation():
+
+    class Book(DynaModel):
+        class Table:
+            name = "books"
+            hash_key = "id"
+            read = 1
+            write = 1
+    
+        class Schema:
+            id = String(required=True)
+            rank = Number(max_value=5)
+            name = String(required=True)
+
+    Book.Table.create_table()
+
+    # ok
+    b = Book(id="foo", rank=1, name="Foos Gold")
+    b.save()
+
+    # no hash key
+    with pytest.raises(ValidationError):
+        b = Book(rank=1, name="Foos Gold")
+        b.save()
+
+    # no required attribute
+    with pytest.raises(ValidationError):
+        b = Book(id="foo", rank=1)
+        b.save()
+
+    # bad type for attribute
+    with pytest.raises(ValidationError):
+        b = Book(id="foo2", rank="bar", name="Foos Gold")
+        b.save()
+
+    # bad semantics - fails custom validation for attribute
+    with pytest.raises(ValidationError):
+        b = Book(id="foo2", rank=10, name="Foos Gold")
+        b.save()
+
+    Book.Table.delete()
+
+
 def test_index_setup():
     """Ensure our index objects are setup & transformed correctly by our meta class"""
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -210,7 +210,13 @@ def test_missing_field_validation():
         )
 
 
-def test_validation():
+def test_validation(dynamo_local):
+
+    if is_marshmallow():
+        from marshmallow.validate import Range
+        number_field = Number(validate=[Range(max=5)])
+    else:
+        number_field = Number(max_value=5)
 
     class Book(DynaModel):
         class Table:
@@ -218,10 +224,10 @@ def test_validation():
             hash_key = "id"
             read = 1
             write = 1
-    
+
         class Schema:
             id = String(required=True)
-            rank = Number(max_value=5)
+            rank = number_field
             name = String(required=True)
 
     Book.Table.create_table()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -214,6 +214,7 @@ def test_validation(dynamo_local):
 
     if is_marshmallow():
         from marshmallow.validate import Range
+
         number_field = Number(validate=[Range(max=5)])
     else:
         number_field = Number(max_value=5)


### PR DESCRIPTION
This PR adds a test (and in time, a fix) for schema validation using `schematics`. It uncovers a bug where _semantic_ validation is not done by `dynamorm_validate`.

Semantic validation here means things like custom validation steps, or things like `max_value=5`. Contrast these with syntactic validation, things like `ConversionError` or `required=True` checks.

See Also: https://github.com/NerdWalletOSS/dynamorm/issues/62

### Checklist

- [x] Tests have been written to cover any new or updated functionality
- [x] All tests pass when running `tox` locally
- [x] The documentation in `docs/` has been updated to cover any changes
- [x] The version in `setup.py` has been bumped to the next version -- follow semver!
- [x] Add an entry to `CHANGELOG.rst` has been added

@NerdWalletOSS/dynamorm
