### PR TITLE
Check if recursive mode is enabled before warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+0.9.13 - 2019.12.12
+###################
+
+* Check that recursive mode is enabled before warning about trying to use both limit and recursive.
+
 0.9.12 - 2019.09.30
 ###################
 

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -909,7 +909,7 @@ class ReadIterator(six.Iterator):
             self.last = self.resp.get("LastEvaluatedKey", None)
 
         # If a Limit is specified we must not operate in recursive mode
-        if "Limit" in self.dynamo_kwargs:
+        if "Limit" in self.dynamo_kwargs and self._recursive:
             log.warning(
                 "%s was invoked with both a limit and the recursive flag set. "
                 "The recursive flag will be ignored",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as readme_fd:
 
 setup(
     name="dynamorm",
-    version="0.9.12",
+    version="0.9.13",
     description="DynamORM is a Python object & relation mapping library for Amazon's DynamoDB service.",
     long_description=long_description,
     author="Evan Borgstrom",


### PR DESCRIPTION
Don't warn when there's a Limit without recursion.

### Checklist

- [ ] Tests have been written to cover any new or updated functionality
- [x] All tests pass when running `tox` locally
- [ ] The documentation in `docs/` has been updated to cover any changes
- [x] The version in `setup.py` has been bumped to the next version -- follow semver!
- [x] Add an entry to `CHANGELOG.rst` has been added

@NerdWalletOSS/dynamorm
