### PR TITLE
Support nested paths in item updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,32 @@
 0.10.0 - 2019.12.18
 ###################
 
-* Enable support for updating nested paths in ``Table.update``.
+* Enable support for updating nested paths in ``Table.update``. Like functions (like ``minus`` or ``if_not_exists``) nested paths are also separated using the double-underscore syntax. For example, given an attribute ``foo`` of an item ``i``:::
 
-  DynamoDB allows updating of nested attributes, using something like JSON path. From the `DynamoDB Developer Guide`_::
+    "foo": {
+        "bar": {
+            "a": 1
+        },
+        "baz": 10
+    }
+
+    i.update(foo__bar__a=42)
+    "foo": {
+        "bar": {
+            "a": 42
+        },
+        "baz": 10
+    }
+
+    i.update(foo__baz__plus=32)
+    "foo": {
+        "bar": {
+            "a": 42
+        },
+        "baz": 42
+    }
+
+  This works because DynamoDB allows updating of nested attributes, using something like JSON path. From the `DynamoDB Developer Guide`_::
 
     aws dynamodb update-item \
         --table-name ProductCatalog \

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,33 @@
+0.10.0 - 2019.12.18
+###################
+
+* Enable support for updating nested paths in ``Table.update``.
+
+  DynamoDB allows updating of nested attributes, using something like JSON path. From the `DynamoDB Developer Guide`_::
+
+    aws dynamodb update-item \
+        --table-name ProductCatalog \
+        --key '{"Id":{"N":"789"}}' \
+        --update-expression "SET #pr.#5star[1] = :r5, #pr.#3star = :r3" \
+        --expression-attribute-names '{
+            "#pr": "ProductReviews",
+            "#5star": "FiveStar",
+            "#3star": "ThreeStar"
+        }' \
+        --expression-attribute-values '{
+            ":r5": { "S": "Very happy with my purchase" },
+            ":r3": {
+                "L": [
+                    { "S": "Just OK - not that great" }
+                ]
+            }
+        }' \
+        --return-values ALL_NEW
+
+  Note that the attribute names along the nested path are broken up - this helps distinguish a nested update from a flat key like ``my.flat.key`` that contains a period.
+
+.. _`DynamoDB Developer Guide`: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.SET.AddingNestedMapAttributes
+
 0.9.14 - 2019.12.13
 ###################
 

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -631,14 +631,18 @@ class DynamoTable3(DynamoCommon3):
             parts, function = parts[:-1], parts[-1]
 
         field_value = ":uv_{0}".format(id_)
-        field_expr_names = OrderedDict([
-            ("#uk_{0}_{1}".format(id_, part_id), part_name)
-            for part_id, part_name in enumerate(parts)
-        ])
+        field_expr_names = OrderedDict(
+            [
+                ("#uk_{0}_{1}".format(id_, part_id), part_name)
+                for part_id, part_name in enumerate(parts)
+            ]
+        )
         field_name = ".".join(six.iterkeys(field_expr_names))
 
         return (
-            UPDATE_FUNCTION_TEMPLATES[function].format(key=field_name, value=field_value),
+            UPDATE_FUNCTION_TEMPLATES[function].format(
+                key=field_name, value=field_value
+            ),
             field_expr_names,
             field_value,
         )
@@ -673,7 +677,11 @@ class DynamoTable3(DynamoCommon3):
                 )
 
             # Add the actual field expression, keys, and value.
-            field_expr, field_expr_names, field_expr_value = self.get_update_expr_for_key(i, key_parts)
+            (
+                field_expr,
+                field_expr_names,
+                field_expr_value,
+            ) = self.get_update_expr_for_key(i, key_parts)
             update_fields.append(field_expr)
             expr_names.update(field_expr_names)
             expr_vals[field_expr_value] = kwargs[key]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as readme_fd:
 
 setup(
     name="dynamorm",
-    version="0.9.14",
+    version="0.10.0",
     description="DynamORM is a Python object & relation mapping library for Amazon's DynamoDB service.",
     long_description=long_description,
     author="Evan Borgstrom",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,8 +153,8 @@ def TestModel():
                 bar = types.StringType(required=True)
                 baz = types.StringType(required=True)
                 count = types.IntType()
-                child = compound.DictType(types.StringType)
-                things = compound.ListType(types.BaseType)
+                child = compound.DictType(types.BaseType)
+                things = compound.ListType(types.StringType)
                 when = types.DateTimeType()
                 created = DynamoTimestampType()
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -385,14 +385,18 @@ def test_update_expressions_nested_paths(TestModel):
     assert two.child == {"sub": "two"}
 
     # Test nested path updates.
-    two.update(child__foo__bar="thing")
-    assert two.child == {"sub": "two", "foo": {"bar": "thing"}}
+    two.update(child__foo={"bar": "thing", "baz": "thing"})
+    assert two.child == {"sub": "two", "foo": {"bar": "thing", "baz": "thing"}}
+    two.update(child__foo__bar="nothing")
+    assert two.child == {"sub": "two", "foo": {"bar": "nothing", "baz": "thing"}}
+    two.update(child__foo={"bar": "nothing"})
+    assert two.child == {"sub": "two", "foo": {"bar": "nothing"}}
 
     # Test an operation (here, `if_not_exists`) on a nested path.
-    two.update(child__foo__bar__if_not_exists="nothing")
-    assert two.child["foo"]["bar"] == "thing"
-    two.update(child__foo__baz__if_not_exists="nothing")
-    assert two.child["foo"]["baz"] == "nothing"
+    two.update(child__foo__bar__if_not_exists="new-thing")
+    assert two.child["foo"]["bar"] == "nothing"
+    two.update(child__foo__baz__if_not_exists="new-thing")
+    assert two.child["foo"]["baz"] == "new-thing"
 
 
 def test_scan_iterator(TestModel, TestModel_entries_xlarge, dynamo_local, mocker):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -349,8 +349,8 @@ def test_update_expressions(TestModel, TestModel_entries, dynamo_local):
     two.update(things__append=["bar"])
     assert two.things == ["foo", "bar"]
 
-    DT = datetime.datetime(2017, 7, 28, 16, 18, 15, 48, tzinfo=dateutil.tz.tzutc())
-    two.update(created=DT)
+    dt = datetime.datetime(2017, 7, 28, 16, 18, 15, 48, tzinfo=dateutil.tz.tzutc())
+    two.update(created=dt)
     assert isinstance(two.created, datetime.datetime)
 
     assert two.count == 222


### PR DESCRIPTION
This PR extends the capability of `Table.update` to allow updating _nested_ fields. For example, given an attribute `foo` of an item `i`:
```
    "foo": {
        "bar": {
            "a": 1
        },
        "baz": 10
    }
```
This PR makes it possible to update `foo.bar` or `foo.baz` indpendently:
```
i.update(foo__bar__a=42)
    "foo": {
        "bar": {
            "a": 42
        },
        "baz": 10
    }
i.update(foo__baz__plus=32)
    "foo": {
        "bar": {
            "a": 42
        },
        "baz": 42
    }
```

It does this by extending the `__` syntax used to attach functions (like `plus`, `minus`, `if_not_exists`, etc) to attach nested attributes as well.

### Checklist

- [x] Tests have been written to cover any new or updated functionality
- [x] All tests pass when running `tox` locally
- [x] The documentation in `docs/` has been updated to cover any changes
- [x] The version in `setup.py` has been bumped to the next version -- follow semver!
- [x] Add an entry to `CHANGELOG.rst` has been added
- [x] Per @borgstrom request, verify this with an actual DynamoDB instance on AWS infra

Note: I verified this on the `dynamorm-test` table in the Nerdwallet Dev account. The test was to manually replicate the unit-test, i.e to check that a nested path could be updated, and a function could be applied as part of the update.

@NerdWalletOSS/dynamorm
