### PR TITLE
Address collections deprecation in Python 3.3+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,11 @@ matrix:
     - python: 3.7
       env: TOXENV=py37-marshmallow-codecov
 
+    - python: 3.8
+      env: TOXENV=py38-schematics-codecov
+    - python: 3.8
+      env: TOXENV=py38-marshmallow-codecov
+
     - python: pypy
       env: TOXENV=pypy2-schematics-codecov
     - python: pypy

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+0.9.15 - 2020.02.06
+###################
+
+* Address ``DeprecationWarning`` for ``collections.abc`` in Python 3.3+
+
 0.9.14 - 2019.12.13
 ###################
 

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,10 @@ DynamORM
            :target: https://pypi.python.org/pypi/dynamorm
            :alt: Latest PyPI version
 
+.. image:: https://img.shields.io/pypi/pyversions/dynamorm.svg
+           :target: https://pypi.python.org/pypi/dynamorm
+           :alt: Supported Python Versions
+
 ----
 
 *This package is a work in progress -- Feedback / Suggestions / Etc welcomed!*

--- a/dynamorm/table.py
+++ b/dynamorm/table.py
@@ -41,10 +41,15 @@ projection  True      object  An instance of of :class:`dynamorm.model.ProjectAl
 
 """
 
-import collections
 import logging
 import time
 import warnings
+from collections import defaultdict
+
+try:
+    from collections.abc import Iterable, Mapping
+except ImportError:
+    from collections import Iterable, Mapping
 
 import boto3
 import botocore
@@ -349,7 +354,7 @@ class DynamoTable3(DynamoCommon3):
                 "The read/write attributes are required to create a table"
             )
 
-        index_args = collections.defaultdict(list)
+        index_args = defaultdict(list)
         for index in six.itervalues(self.indexes):
             index_args[index.ARG_KEY].append(index.index_args)
 
@@ -626,9 +631,9 @@ class DynamoTable3(DynamoCommon3):
         update_item_kwargs["ExpressionAttributeNames"] = expr_names
         update_item_kwargs["ExpressionAttributeValues"] = expr_vals
 
-        if isinstance(conditions, collections.Mapping):
+        if isinstance(conditions, Mapping):
             condition_expression = Q(**conditions)
-        elif isinstance(conditions, collections.Iterable):
+        elif isinstance(conditions, Iterable):
             condition_expression = None
             for condition in conditions:
                 try:
@@ -803,7 +808,7 @@ def get_expression(attr, op, value):
         # otherwise we bubble it up.
         if value is True:
             return op()
-        elif isinstance(value, collections.Iterable):
+        elif isinstance(value, Iterable):
             return op(*value)
         else:
             raise

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,11 @@ setup(
     packages=["dynamorm", "dynamorm.types"],
     classifiers=[
         "Development Status :: 4 - Beta",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as readme_fd:
 
 setup(
     name="dynamorm",
-    version="0.9.14",
+    version="0.9.15",
     description="DynamORM is a Python object & relation mapping library for Amazon's DynamoDB service.",
     long_description=long_description,
     author="Evan Borgstrom",

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
     pypy2: pypy
     pypy3: pypy3
 


### PR DESCRIPTION
This PR addresses the `collections` deprecation warnings reported in #90 

### Checklist

- [x] Tests have been written to cover any new or updated functionality
- [x] All tests pass when running `tox` locally
- [x] The documentation in `docs/` has been updated to cover any changes
- [x] The version in `setup.py` has been bumped to the next version -- follow semver!
- [x] Add an entry to `CHANGELOG.rst` has been added

@NerdWalletOSS/dynamorm

Closes #90 