### PR TITLE
Allow for Schema to subclass existing Models

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,48 @@
+0.11.0 - 2020.08.24
+###################
+
+* **BREAKING** Inner ``Schema`` classes that use inheritance must use bases that explicitly extend from the base class of the serialization package.
+
+  Previously this was allowed::
+
+    from schematics.types import StringType
+
+
+    class Mixin:
+        foo = StringType(required=True)
+
+    class MyModel(DynaModel):
+        class Table:
+            name = "table"
+            hash_key = "foo"
+            read = 1
+            write = 1
+
+        class Schema(Mixin):
+            bar = StringType()
+
+  DynamORM would implicitly add the base Schematics model to the MRO of the Schema. However, this caused problems when you want to use an explicitly declared model as the base mixin since our serialization packages already apply metaclass logic to the fields.
+
+  Now, you must always explicitly inherit from the base class::
+
+    from schematics.models import Model
+    from schematics.types import StringType
+
+
+    class Mixin(Model):
+        foo = String(required=True)
+
+    class MyModel(DynaModel):
+        class Table:
+            name = "table"
+            hash_key = "foo"
+            read = 1
+            write = 1
+
+        class Schema(Mixin):
+            bar = String()
+
+
 0.10.0 - 2020.02.05
 ###################
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@
         class Schema(Mixin):
             bar = String()
 
+ * The internal ``DynamORMSchema.base_field_type()`` function was unused and has been removed
 
 0.10.0 - 2020.02.05
 ###################

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -89,7 +89,9 @@ class DynaModelMeta(type):
 
             if issubclass(attrs["Schema"], Schema.base_schema_type()):
                 SchemaClass = type(
-                    "{name}Schema".format(name=name), (Schema, attrs["Schema"]), {},
+                    "{name}Schema".format(name=name),
+                    (Schema, attrs["Schema"]),
+                    {},
                 )
             else:
                 SchemaClass = type(
@@ -481,8 +483,7 @@ class DynaModel(object):
         return self.update(update_item_kwargs=kwargs, return_all=return_all, **updates)
 
     def _add_hash_key_values(self, hash_dict):
-        """Mutate a dictionary to add key: value pair for a hash and (if specified) sort key.
-        """
+        """Mutate a dictionary to add key: value pair for a hash and (if specified) sort key."""
         hash_dict[self.Table.hash_key] = getattr(self, self.Table.hash_key)
         try:
             hash_dict[self.Table.range_key] = getattr(self, self.Table.range_key)

--- a/dynamorm/model.py
+++ b/dynamorm/model.py
@@ -64,7 +64,9 @@ class DynaModelMeta(type):
                 except AttributeError:
                     continue
 
-                if inspect.isclass(parent_attr) and issubclass(parent_attr, inner_class):
+                if inspect.isclass(parent_attr) and issubclass(
+                    parent_attr, inner_class
+                ):
                     return False
                 elif isinstance(parent_attr, inner_class):
                     return False
@@ -101,9 +103,7 @@ class DynaModelMeta(type):
         if should_transform("Schema", Schema):
             if issubclass(attrs["Schema"], Schema.base_schema_type()):
                 SchemaClass = type(
-                    "{name}Schema".format(name=name),
-                    (Schema, attrs["Schema"]),
-                    {},
+                    "{name}Schema".format(name=name), (Schema, attrs["Schema"]), {},
                 )
             else:
                 SchemaClass = type(

--- a/dynamorm/types/_marshmallow.py
+++ b/dynamorm/types/_marshmallow.py
@@ -69,3 +69,8 @@ class Schema(MarshmallowSchema, DynamORMSchema):
     @staticmethod
     def base_field_type():
         return fields.Field
+
+    @staticmethod
+    def base_schema_type():
+        return MarshmallowSchema
+

--- a/dynamorm/types/_marshmallow.py
+++ b/dynamorm/types/_marshmallow.py
@@ -73,4 +73,3 @@ class Schema(MarshmallowSchema, DynamORMSchema):
     @staticmethod
     def base_schema_type():
         return MarshmallowSchema
-

--- a/dynamorm/types/_marshmallow.py
+++ b/dynamorm/types/_marshmallow.py
@@ -67,9 +67,5 @@ class Schema(MarshmallowSchema, DynamORMSchema):
         return data
 
     @staticmethod
-    def base_field_type():
-        return fields.Field
-
-    @staticmethod
     def base_schema_type():
         return MarshmallowSchema

--- a/dynamorm/types/_schematics.py
+++ b/dynamorm/types/_schematics.py
@@ -37,9 +37,5 @@ class Schema(SchematicsModel, DynamORMSchema):
             return inst.to_primitive()
 
     @staticmethod
-    def base_field_type():
-        return types.BaseType
-
-    @staticmethod
     def base_schema_type():
         return SchematicsModel

--- a/dynamorm/types/_schematics.py
+++ b/dynamorm/types/_schematics.py
@@ -39,3 +39,7 @@ class Schema(SchematicsModel, DynamORMSchema):
     @staticmethod
     def base_field_type():
         return types.BaseType
+
+    @staticmethod
+    def base_schema_type():
+        return SchematicsModel

--- a/dynamorm/types/base.py
+++ b/dynamorm/types/base.py
@@ -39,3 +39,9 @@ class DynamORMSchema(object):
     def base_field_type():
         """Returns the class that all fields in the schema will inherit from"""
         raise NotImplementedError("Child class must implement base_field_type")
+
+    @staticmethod
+    def base_schema_type():
+        """Returns the base class used for schemas of this type"""
+        raise NotImplementedError("Child class must implement schema_base_class")
+

--- a/dynamorm/types/base.py
+++ b/dynamorm/types/base.py
@@ -36,11 +36,6 @@ class DynamORMSchema(object):
         )
 
     @staticmethod
-    def base_field_type():
-        """Returns the class that all fields in the schema will inherit from"""
-        raise NotImplementedError("Child class must implement base_field_type")
-
-    @staticmethod
     def base_schema_type():
         """Returns the base class used for schemas of this type"""
         raise NotImplementedError("Child class must implement schema_base_class")

--- a/dynamorm/types/base.py
+++ b/dynamorm/types/base.py
@@ -44,4 +44,3 @@ class DynamORMSchema(object):
     def base_schema_type():
         """Returns the base class used for schemas of this type"""
         raise NotImplementedError("Child class must implement schema_base_class")
-

--- a/dynamorm/types/base.py
+++ b/dynamorm/types/base.py
@@ -38,4 +38,4 @@ class DynamORMSchema(object):
     @staticmethod
     def base_schema_type():
         """Returns the base class used for schemas of this type"""
-        raise NotImplementedError("Child class must implement schema_base_class")
+        raise NotImplementedError("Child class must implement base_schema_type")

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,7 @@ test=pytest
 [flake8]
 exclude=./build/*,./configs/*,*.egg-info/*,.eggs/*
 max_line_length=160
+
+[coverage:run]
+omit =
+    dynamorm/types/base.py

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as readme_fd:
 
 setup(
     name="dynamorm",
-    version="0.10.0",
+    version="0.11.0",
     description="DynamORM is a Python object & relation mapping library for Amazon's DynamoDB service.",
     long_description=long_description,
     author="Evan Borgstrom",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -666,20 +666,6 @@ def test_model_mixin():
     assert isinstance(MyModel.Schema.dynamorm_fields()["bar"], String)
 
 
-def test_explicit_subclass():
-    class MyModel(DynaModel):
-        class Table:
-            name = "table"
-            hash_key = "foo"
-            read = 1
-            write = 1
-
-        class Schema(BaseModel):
-            foo = String(required=True)
-
-    assert isinstance(MyModel.Schema.dynamorm_fields()["foo"], String)
-
-
 def test_table_config(TestModel, dynamo_local):
     class MyModel(DynaModel):
         class Table:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -666,6 +666,20 @@ def test_model_mixin():
     assert isinstance(MyModel.Schema.dynamorm_fields()["bar"], String)
 
 
+def test_explicit_subclass():
+    class MyModel(DynaModel):
+        class Table:
+            name = "table"
+            hash_key = "foo"
+            read = 1
+            write = 1
+
+        class Schema(BaseModel):
+            foo = String(required=True)
+
+    assert isinstance(MyModel.Schema.dynamorm_fields()["foo"], String)
+
+
 def test_table_config(TestModel, dynamo_local):
     class MyModel(DynaModel):
         class Table:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -18,7 +18,11 @@ def is_marshmallow():
 
 if is_marshmallow():
     from marshmallow.fields import String, Integer as Number, UUID
-    from marshmallow import validates, ValidationError as SchemaValidationError, Schema as BaseModel
+    from marshmallow import (
+        validates,
+        ValidationError as SchemaValidationError,
+        Schema as BaseModel,
+    )
 else:
     from schematics.exceptions import ValidationError as SchemaValidationError
     from schematics.types import (

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -18,14 +18,15 @@ def is_marshmallow():
 
 if is_marshmallow():
     from marshmallow.fields import String, Integer as Number, UUID
-    from marshmallow import validates, ValidationError as SchemaValidationError
+    from marshmallow import validates, ValidationError as SchemaValidationError, Schema as Model
 else:
+    from schematics.exceptions import ValidationError as SchemaValidationError
     from schematics.types import (
         StringType as String,
         IntType as Number,
         UUIDType as UUID,
     )
-    from schematics.exceptions import ValidationError as SchemaValidationError
+    from schematics.models import Model
 
 try:
     from unittest.mock import MagicMock, call
@@ -636,6 +637,24 @@ def test_schema_parents_mro():
         class Schema(MixinOne, MixinTwo):
             foo = Number(required=True)
             baz = String(required=True)
+
+    assert "bar" in Model.Schema.dynamorm_fields()
+    assert isinstance(Model.Schema.dynamorm_fields()["bar"], String)
+
+
+def test_model_mixin():
+    class Mixin(Model):
+        bar = Number()
+
+    class Model(DynaModel):
+        class Table:
+            name = "table"
+            hash_key = "foo"
+            read = 1
+            write = 1
+
+        class Schema(Mixin):
+            foo = Number(required=True)
 
     assert "bar" in Model.Schema.dynamorm_fields()
     assert isinstance(Model.Schema.dynamorm_fields()["bar"], String)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -318,7 +318,7 @@ def test_schema_field_removed_update_return_all(
     TestModel, TestModel_table, dynamo_local
 ):
     """Simulate a schema change with field removed and make sure we can update the record
-       and return all columns with new schema
+    and return all columns with new schema
     """
     data = {"foo": "1", "bar": "2", "old_schema_key": 10, "baz": "baz"}
     TestModel.Table.put(data)


### PR DESCRIPTION
@CamiloValderruten discovered that trying to use inner Schema inheritance with an explicit model was broken. It only worked with an object that didn't have a metaclass transform the base class before our own transformations.

We currently have a bunch of pull-up logic that is ultimately pretty fragile so the solution to fix the original problem and remove some of the fragility is to require users to explicitly make their Schema classes extend from their serialization package's model class. For users who do not need to leverage inheritance we still implicitly mixin the base serialization package model class.

@NerdWalletOSS/dynamorm 